### PR TITLE
feat(cli): add update-notifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "node-filter-async": "^1.1.3",
     "npm-check-updates": "^3.1.21",
     "oclif": "^1.13.5",
-    "pjson": "^1.0.9",
     "reflect-metadata": "^0.1.13",
     "semver": "^6.3.0",
     "simple-git": "^1.124.0",

--- a/package.json
+++ b/package.json
@@ -42,13 +42,15 @@
     "node-filter-async": "^1.1.3",
     "npm-check-updates": "^3.1.21",
     "oclif": "^1.13.5",
+    "pjson": "^1.0.9",
     "reflect-metadata": "^0.1.13",
     "semver": "^6.3.0",
     "simple-git": "^1.124.0",
     "toposort": "^2.0.2",
     "ts-node": "^8",
     "tslib": "^1",
-    "typescript": "^3.5"
+    "typescript": "^3.5",
+    "update-notifier": "^3.0.1"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^3.0.4",
@@ -62,6 +64,7 @@
     "@types/rimraf": "^2.0.2",
     "@types/semver": "^6.0.1",
     "@types/toposort": "^2.0.3",
+    "@types/update-notifier": "^2.5.0",
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "codecov": "^3.5.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ import { Scanner } from './scanner/Scanner';
 import { Command, flags } from '@oclif/command';
 import cli from 'cli-ux';
 import { ServiceError } from './lib/errors';
-import pkg from 'pjson';
 import updateNotifier from 'update-notifier';
 
 class DXScannerCommand extends Command {
@@ -29,7 +28,7 @@ class DXScannerCommand extends Command {
     let authorization = flags.authorization ? flags.authorization : undefined;
     const json = flags.json ? flags.json : undefined;
 
-    const notifier = updateNotifier({ pkg });
+    const notifier = updateNotifier({ pkg: this.config.pjson });
 
     // const name = flags.name || 'world';
     // this.log(`hello ${name} from ./src/index.ts`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ class DXScannerCommand extends Command {
       }
     }
     cli.action.stop();
-    notifier.notify();
+    notifier.notify({ isGlobal: true });
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ import { Scanner } from './scanner/Scanner';
 import { Command, flags } from '@oclif/command';
 import cli from 'cli-ux';
 import { ServiceError } from './lib/errors';
+import pkg from 'pjson';
+import updateNotifier from 'update-notifier';
 
 class DXScannerCommand extends Command {
   static description = 'Scan your project for possible DX recommendations.';
@@ -26,6 +28,8 @@ class DXScannerCommand extends Command {
     const { args, flags } = this.parse(DXScannerCommand);
     let authorization = flags.authorization ? flags.authorization : undefined;
     const json = flags.json ? flags.json : undefined;
+
+    const notifier = updateNotifier({ pkg });
 
     // const name = flags.name || 'world';
     // this.log(`hello ${name} from ./src/index.ts`);
@@ -53,8 +57,8 @@ class DXScannerCommand extends Command {
         throw error;
       }
     }
-
     cli.action.stop();
+    notifier.notify();
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -778,6 +778,11 @@
   resolved "https://registry.yarnpkg.com/@types/toposort/-/toposort-2.0.3.tgz#dc490842b77c3e910c8d727ff0bdb2fb124cb41b"
   integrity sha512-jRtyvEu0Na/sy0oIxBW0f6wPQjidgVqlmCTJVHEGTNEUdL1f0YSvdPzHY7nX7MUWAZS6zcAa0KkqofHjy/xDZQ==
 
+"@types/update-notifier@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@types/update-notifier/-/update-notifier-2.5.0.tgz#63cfcee92cc915f9a6eea4d1442ec6efd012e118"
+  integrity sha512-YV+ZcSIiv30GhLM7WwxI+bsbcW34d3Yhl2JSFBNFL6qtfsoI9++hogxz+jTqeS86ynKcMUE0AsnLWQynfJnsfA==
+
 "@types/yargs-parser@*":
   version "13.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-13.0.0.tgz#453743c5bbf9f1bed61d959baab5b06be029b2d0"
@@ -6668,6 +6673,11 @@ pirates@^4.0.1:
   integrity sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==
   dependencies:
     node-modules-regexp "^1.0.0"
+
+pjson@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/pjson/-/pjson-1.0.9.tgz#8a9520ce76a4739f8fee91679dad6b065b1c7938"
+  integrity sha512-4hRJH3YzkUpOlShRzhyxAmThSNnAaIlWZCAb27hd0pVUAXNUAHAO7XZbsPPvsCYwBFEScTmCCL6DGE8NyZ8BdQ==
 
 pkg-conf@^2.1.0:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6674,11 +6674,6 @@ pirates@^4.0.1:
   dependencies:
     node-modules-regexp "^1.0.0"
 
-pjson@^1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/pjson/-/pjson-1.0.9.tgz#8a9520ce76a4739f8fee91679dad6b065b1c7938"
-  integrity sha512-4hRJH3YzkUpOlShRzhyxAmThSNnAaIlWZCAb27hd0pVUAXNUAHAO7XZbsPPvsCYwBFEScTmCCL6DGE8NyZ8BdQ==
-
 pkg-conf@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/pkg-conf/-/pkg-conf-2.1.0.tgz#2126514ca6f2abfebd168596df18ba57867f0058"


### PR DESCRIPTION
Fixes #70

I have added [update-notifier](https://www.npmjs.com/package/update-notifier) with its default prompt.

update-notifier uses [is-installed-globally](https://github.com/sindresorhus/is-installed-globally) package to detect whether to show `npm i -g` in the message. The autodetection didn't work correctly for me, either because I have linked the package with `yarn link` or because it was run in other Node projects. Because the recommended use is to have this utility installed globally, I have forced the `isGlobal` option.

## Testing

Change `version` field in `package.json` to lower version than published and run the CLI with `bin/run`. You should see the notification:

![image](https://user-images.githubusercontent.com/616767/66045287-b2ecf300-e523-11e9-9bf6-97097229ba7a.png)

To retest, remove or modify `~/.config/configstore/update-notifier-dx-scanner.json` file.
