### PR TITLE
Language detector for C#

### DIFF
--- a/src/detectors/CSharp/CSharpLanguageDetector.spec.ts
+++ b/src/detectors/CSharp/CSharpLanguageDetector.spec.ts
@@ -1,0 +1,60 @@
+import { CSharpLanguageDetector } from './CSharpLanguageDetector';
+import { FileInspector } from '../../inspectors/FileInspector';
+import { ProgrammingLanguage } from '../../model';
+import { FileSystemService } from '../../services/FileSystemService';
+import * as nodePath from 'path';
+import { DirectoryJSON } from 'memfs/lib/volume';
+
+describe('CSharpLanguageDetector', () => {
+  let detector: CSharpLanguageDetector;
+  let virtualFileSystemService: FileSystemService;
+
+  beforeEach(() => {
+    virtualFileSystemService = new FileSystemService({ isVirtual: true });
+
+    const fileInspector = new FileInspector(virtualFileSystemService, '/');
+    detector = new CSharpLanguageDetector(fileInspector);
+  });
+
+  afterEach(async () => {
+    virtualFileSystemService.clearFileSystem();
+  });
+
+  it('detects C# correctly via a .csproj file', async () => {
+    const structure: DirectoryJSON = {
+      '/project.csproj': '...',
+    };
+
+    virtualFileSystemService.setFileSystem(structure);
+
+    const langAtPath = await detector.detectLanguage();
+    expect(langAtPath.length).toEqual(1);
+    expect(langAtPath[0].language).toEqual(ProgrammingLanguage.CSharp);
+    expect(langAtPath[0].path).toEqual(nodePath.sep);
+  });
+
+  it("detects it's not a C#", async () => {
+    const structure: DirectoryJSON = {
+      '/src/index.none': '...',
+    };
+
+    virtualFileSystemService.setFileSystem(structure);
+
+    const langAtPath = await detector.detectLanguage();
+    expect(langAtPath.length).toEqual(0);
+    expect(langAtPath).toEqual([]);
+  });
+
+  it('detects C# correctly via cs file', async () => {
+    const structure: DirectoryJSON = {
+      '/calculator.cs': '...',
+    };
+
+    virtualFileSystemService.setFileSystem(structure);
+
+    const langAtPath = await detector.detectLanguage();
+    expect(langAtPath.length).toEqual(1);
+    expect(langAtPath[0].language).toEqual(ProgrammingLanguage.CSharp);
+    expect(langAtPath[0].path).toEqual(nodePath.sep);
+  });
+});

--- a/src/detectors/CSharp/CSharpLanguageDetector.ts
+++ b/src/detectors/CSharp/CSharpLanguageDetector.ts
@@ -1,0 +1,35 @@
+import { ILanguageDetector } from '../ILanguageDetector';
+import { injectable, inject } from 'inversify';
+import { LanguageAtPath, ProgrammingLanguage } from '../../model';
+import { IFileInspector } from '../../inspectors/IFileInspector';
+import { Types } from '../../types';
+import { fileNameRegExp, fileExtensionRegExp, sharedSubpath } from '../utils';
+import { uniq } from 'lodash';
+import * as nodePath from 'path';
+
+@injectable()
+export class CSharpLanguageDetector implements ILanguageDetector {
+  private fileInspector: IFileInspector;
+  constructor(@inject(Types.IFileInspector) fileInspector: IFileInspector) {
+    this.fileInspector = fileInspector;
+  }
+
+  async detectLanguage(): Promise<LanguageAtPath[]> {
+    const csprojFiles = await this.fileInspector.scanFor(fileExtensionRegExp(['csproj']), '/');
+    const projectDirs : LanguageAtPath[] = csprojFiles
+      .map(proj => nodePath.dirname(proj.path))
+      .map(path => ({ path, language: ProgrammingLanguage.CSharp}));
+    if(projectDirs.length > 0) {
+      return projectDirs
+    }
+    const cSharpFiles = await this.fileInspector.scanFor(fileExtensionRegExp(['cs']), '/');
+    const dirsWithProjects = uniq(cSharpFiles.map((f) => nodePath.dirname(f.path))); 
+    if(dirsWithProjects.length === 0) {
+      return [];
+    }
+    return [{ 
+      language: ProgrammingLanguage.CSharp, 
+      path: sharedSubpath(dirsWithProjects)
+    }];
+  }
+}


### PR DESCRIPTION
Created a language detector for C#. Checks for C# project files (.csproj) as well as C# code files (.cs).

Did not set this up in `scannerContextBinding.ts`, since I do not know if that has benefit without any improvement suggestions for C# yet.