### PR TITLE
feat(practices): split gitignore correctly set to separated JS & TS

### DIFF
--- a/src/practices/LanguageIndependent/GitignoreIsPresentPractice.spec.ts
+++ b/src/practices/LanguageIndependent/GitignoreIsPresentPractice.spec.ts
@@ -1,15 +1,15 @@
-import { JsGitignoreIsPresentPractice } from './JsGitignoreIsPresentPractice';
+import { GitignoreIsPresentPractice } from './GitignoreIsPresentPractice';
 import { PracticeEvaluationResult } from '../../model';
 import { TestContainerContext, createTestContainer } from '../../inversify.config';
 
-describe('JsGitignoreIsPresentPractice', () => {
-  let practice: JsGitignoreIsPresentPractice;
+describe('GitignoreIsPresentPractice', () => {
+  let practice: GitignoreIsPresentPractice;
   let containerCtx: TestContainerContext;
 
   beforeAll(() => {
     containerCtx = createTestContainer();
-    containerCtx.container.bind('JsGitignoreIsPresentPractice').to(JsGitignoreIsPresentPractice);
-    practice = containerCtx.container.get('JsGitignoreIsPresentPractice');
+    containerCtx.container.bind('GitignoreIsPresentPractice').to(GitignoreIsPresentPractice);
+    practice = containerCtx.container.get('GitignoreIsPresentPractice');
   });
 
   afterEach(async () => {

--- a/src/practices/LanguageIndependent/GitignoreIsPresentPractice.ts
+++ b/src/practices/LanguageIndependent/GitignoreIsPresentPractice.ts
@@ -12,7 +12,7 @@ import { PracticeContext } from '../../contexts/practice/PracticeContext';
   reportOnlyOnce: true,
   url: 'https://git-scm.com/docs/gitignore',
 })
-export class JsGitignoreIsPresentPractice implements IPractice {
+export class GitignoreIsPresentPractice implements IPractice {
   async isApplicable(ctx: PracticeContext): Promise<boolean> {
     return (
       ctx.projectComponent.language === ProgrammingLanguage.JavaScript || ctx.projectComponent.language === ProgrammingLanguage.TypeScript

--- a/src/practices/TypeScript/TsGitignoreCorrectlySetPractice.spec.ts
+++ b/src/practices/TypeScript/TsGitignoreCorrectlySetPractice.spec.ts
@@ -1,0 +1,43 @@
+import { TsGitignoreCorrectlySetPractice } from './TsGitignoreCorrectlySetPractice';
+import { gitignoreContent } from '../../detectors/__MOCKS__/gitignoreContent.mock';
+import { PracticeEvaluationResult } from '../../model';
+import { TestContainerContext, createTestContainer } from '../../inversify.config';
+
+describe('TsGitignoreCorrectlySetPractice', () => {
+  let practice: TsGitignoreCorrectlySetPractice;
+  let containerCtx: TestContainerContext;
+
+  beforeAll(() => {
+    containerCtx = createTestContainer();
+    containerCtx.container.bind('TsGitignoreCorrectlySetPractice').to(TsGitignoreCorrectlySetPractice);
+    practice = containerCtx.container.get('TsGitignoreCorrectlySetPractice');
+  });
+
+  afterEach(async () => {
+    containerCtx.virtualFileSystemService.clearFileSystem();
+    containerCtx.practiceContext.fileInspector!.purgeCache();
+  });
+
+  it('Returns practicing if the .gitignore is set correctly', async () => {
+    containerCtx.virtualFileSystemService.setFileSystem({
+      '.gitignore': gitignoreContent,
+    });
+
+    const evaluated = await practice.evaluate(containerCtx.practiceContext);
+    expect(evaluated).toEqual(PracticeEvaluationResult.practicing);
+  });
+
+  it('Returns notPracticing if there the .gitignore is NOT set correctly', async () => {
+    containerCtx.virtualFileSystemService.setFileSystem({
+      '.gitignore': '...',
+    });
+
+    const evaluated = await practice.evaluate(containerCtx.practiceContext);
+    expect(evaluated).toEqual(PracticeEvaluationResult.notPracticing);
+  });
+
+  it('Returns unknown if there is no fileInspector', async () => {
+    const evaluated = await practice.evaluate({ ...containerCtx.practiceContext, fileInspector: undefined });
+    expect(evaluated).toEqual(PracticeEvaluationResult.unknown);
+  });
+});

--- a/src/practices/TypeScript/TsGitignoreCorrectlySetPractice.ts
+++ b/src/practices/TypeScript/TsGitignoreCorrectlySetPractice.ts
@@ -4,7 +4,7 @@ import { DxPractice } from '../DxPracticeDecorator';
 import { PracticeContext } from '../../contexts/practice/PracticeContext';
 
 @DxPractice({
-  id: 'JavaScript.GitignoreCorrectlySet',
+  id: 'TypeScript.GitignoreCorrectlySet',
   name: 'Set .gitignore Correctly',
   impact: PracticeImpact.high,
   suggestion: 'Scripts in the .gitignore set as usual.',
@@ -12,9 +12,9 @@ import { PracticeContext } from '../../contexts/practice/PracticeContext';
   url: 'https://github.com/github/gitignore/blob/master/Node.gitignore',
   dependsOn: { practicing: ['LanguageIndependent.GitignoreIsPresent'] },
 })
-export class JsGitignoreCorrectlySetPractice implements IPractice {
+export class TsGitignoreCorrectlySetPractice implements IPractice {
   async isApplicable(ctx: PracticeContext): Promise<boolean> {
-    return ctx.projectComponent.language === ProgrammingLanguage.JavaScript;
+    return ctx.projectComponent.language === ProgrammingLanguage.TypeScript;
   }
 
   async evaluate(ctx: PracticeContext): Promise<PracticeEvaluationResult> {
@@ -31,6 +31,10 @@ export class JsGitignoreCorrectlySetPractice implements IPractice {
     const content = await ctx.fileInspector.readFile('.gitignore');
     const parsedGitignore = parseGitignore(content);
 
+    // folders with compiled code
+    const buildRegex = parsedGitignore.find((value: string) => /build/.test(value));
+    const libRegex = parsedGitignore.find((value: string) => /lib/.test(value));
+    const distRegex = parsedGitignore.find((value: string) => /dist/.test(value));
     // lockfiles
     const packageJsonRegex = parsedGitignore.find((value: string) => /package-lock\.json/.test(value));
     const yarnLockRegex = parsedGitignore.find((value: string) => /yarn\.lock/.test(value));
@@ -41,7 +45,14 @@ export class JsGitignoreCorrectlySetPractice implements IPractice {
     const errorLogRegex = parsedGitignore.find((value: string) => /\.log/.test(value));
     const debugRegex = parsedGitignore.find((value: string) => /debug/.test(value));
 
-    if ((packageJsonRegex || yarnLockRegex) && nodeModulesRegex && debugRegex && errorLogRegex && coverageRegex) {
+    if (
+      (buildRegex || libRegex || distRegex) &&
+      (packageJsonRegex || yarnLockRegex) &&
+      nodeModulesRegex &&
+      debugRegex &&
+      errorLogRegex &&
+      coverageRegex
+    ) {
       return PracticeEvaluationResult.practicing;
     }
 

--- a/src/practices/index.ts
+++ b/src/practices/index.ts
@@ -14,10 +14,11 @@ import { JsPackageManagementUsedPractice } from './JavaScript/JsPackageManagemen
 import { DeprecatedTSLintPractice } from './JavaScript/DeprecatedTSLintPractice';
 import { DockerizationUsedPractice } from './LanguageIndependent/DockerizationUsedPractice';
 import { EditorConfigIsPresentPractice } from './LanguageIndependent/EditorConfigIsPresentPractice';
-import { JsGitignoreIsPresentPractice } from './JavaScript/JsGitignoreIsPresentPractice';
+import { GitignoreIsPresentPractice } from './LanguageIndependent/GitignoreIsPresentPractice';
 import { JsGitignoreCorrectlySetPractice } from './JavaScript/JsGitignoreCorrectlySetPractice';
 import { DependenciesVersionPractice } from './JavaScript/DependenciesVersionPractice';
 import { ESLintWithoutErrorsPractice } from './JavaScript/ESLintWithoutErrorsPractice';
+import { TsGitignoreCorrectlySetPractice } from './TypeScript/TsGitignoreCorrectlySetPractice';
 
 // register practices here
 export const practices = [
@@ -39,6 +40,7 @@ export const practices = [
   DockerizationUsedPractice,
   EditorConfigIsPresentPractice,
   DependenciesVersionPractice,
-  JsGitignoreIsPresentPractice,
+  GitignoreIsPresentPractice,
   JsGitignoreCorrectlySetPractice,
+  TsGitignoreCorrectlySetPractice,
 ];


### PR DESCRIPTION
split gitignore correctly set to separated JS & TS
- because JS and TS has different content (e.g. JS doesn't have a build/dist folder)