### PR TITLE
fix(bitbucket): do not require bitbucket credentials twice

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ class DXScannerCommand extends Command {
     version: flags.version({ char: 'v', description: 'Output the version number' }),
     help: flags.help({ char: 'h', description: 'Help' }),
     // flag with a value (-n, --name=VALUE)
-    authorization: flags.string({ char: 'a', description: 'Credentials to the repository.' }),
+    authorization: flags.string({ char: 'a', description: 'Credentials to the repository. (in format "token" or "username:token")' }),
     json: flags.boolean({ char: 'j', description: 'Print report in JSON' }),
     recursive: flags.boolean({ char: 'r', description: 'Scan all components recursively in all sub folders' }),
     init: flags.boolean({ char: 'i', description: 'Initialize DX Scanner configuration' }),

--- a/src/scanner/Scanner.ts
+++ b/src/scanner/Scanner.ts
@@ -89,6 +89,14 @@ export class Scanner {
     if (localPath === undefined && remoteUrl !== undefined && serviceType !== ServiceType.local) {
       const cloneUrl = new url.URL(remoteUrl);
       localPath = fs.mkdtempSync(path.join(os.tmpdir(), 'dx-scanner'));
+
+      if (this.argumentsProvider.auth?.includes(':')) {
+        cloneUrl.username = this.argumentsProvider.auth.split(':')[0];
+        cloneUrl.password = this.argumentsProvider.auth.split(':')[1];
+      } else if (this.argumentsProvider.auth) {
+        cloneUrl.password = this.argumentsProvider.auth;
+      }
+
       await git()
         .silent(true)
         .clone(cloneUrl.href, localPath);


### PR DESCRIPTION
Fixed twice required bitbucket credentials when repository shared to me.

Need to finish:
- [x] copy&paste new help to readme
- [x] TBD how to implement it to CI to test all these cases

Related to #153 