### PR TITLE
fix(cli): remove sh because windows doesn't have it installed

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -1,5 +1,4 @@
-#!/bin/sh
-":" //# http://sambal.org/?p=1014 ; exec /usr/bin/env node --no-warnings "$0" "$@"
+#!/usr/bin/env node
 /* eslint-disable @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports */
 
 const fs = require('fs');


### PR DESCRIPTION
It's not possible to run the dx-scanner with `/bin/sh` because it isn't installed at all.

Related to #155 