### PR TITLE
Do not require lockfiles in gitignore practice

### DIFF
--- a/src/practices/JavaScript/JsGitignoreCorrectlySetPractice.spec.ts
+++ b/src/practices/JavaScript/JsGitignoreCorrectlySetPractice.spec.ts
@@ -47,13 +47,13 @@ describe('JsGitignoreCorrectlySetPractice', () => {
     expect(evaluated).toEqual(PracticeEvaluationResult.unknown);
   });
 
-  it('Returns practicing if there are no lockfiles in .gitignore', async () => {
+  it('Returns notPracticing if there are no lockfiles in .gitignore', async () => {
     containerCtx.virtualFileSystemService.setFileSystem({
       '.gitignore': basicGitignore,
     });
 
     const evaluated = await practice.evaluate(containerCtx.practiceContext);
-    expect(evaluated).toEqual(PracticeEvaluationResult.practicing);
+    expect(evaluated).toEqual(PracticeEvaluationResult.notPracticing);
   });
 
   it('Returns practicing if there is only one lockfile in .gitignore', async () => {

--- a/src/practices/JavaScript/JsGitignoreCorrectlySetPractice.ts
+++ b/src/practices/JavaScript/JsGitignoreCorrectlySetPractice.ts
@@ -31,13 +31,16 @@ export class JsGitignoreCorrectlySetPractice implements IPractice {
     const content = await ctx.root.fileInspector.readFile('.gitignore');
     const parsedGitignore = parseGitignore(content);
 
+    // lockfiles
+    const packageJsonRegex = parsedGitignore.find((value: string) => /package-lock\.json/.test(value));
+    const yarnLockRegex = parsedGitignore.find((value: string) => /yarn\.lock/.test(value));
     // node_modules
     const nodeModulesRegex = parsedGitignore.find((value: string) => /node_modules/.test(value));
     // misc
     const coverageRegex = parsedGitignore.find((value: string) => /coverage/.test(value));
     const errorLogRegex = parsedGitignore.find((value: string) => /\.log/.test(value));
 
-    if (nodeModulesRegex && errorLogRegex && coverageRegex) {
+    if (!(packageJsonRegex && yarnLockRegex) && nodeModulesRegex && errorLogRegex && coverageRegex) {
       return PracticeEvaluationResult.practicing;
     }
 

--- a/src/practices/JavaScript/JsGitignoreCorrectlySetPractice.ts
+++ b/src/practices/JavaScript/JsGitignoreCorrectlySetPractice.ts
@@ -40,7 +40,9 @@ export class JsGitignoreCorrectlySetPractice implements IPractice {
     const coverageRegex = parsedGitignore.find((value: string) => /coverage/.test(value));
     const errorLogRegex = parsedGitignore.find((value: string) => /\.log/.test(value));
 
-    if (!(packageJsonRegex && yarnLockRegex) && nodeModulesRegex && errorLogRegex && coverageRegex) {
+    const exactlyOneLockfile = (packageJsonRegex && !yarnLockRegex) || (!packageJsonRegex && yarnLockRegex);
+
+    if (exactlyOneLockfile && nodeModulesRegex && errorLogRegex && coverageRegex) {
       return PracticeEvaluationResult.practicing;
     }
 

--- a/src/practices/JavaScript/JsGitignoreCorrectlySetPractice.ts
+++ b/src/practices/JavaScript/JsGitignoreCorrectlySetPractice.ts
@@ -31,16 +31,13 @@ export class JsGitignoreCorrectlySetPractice implements IPractice {
     const content = await ctx.root.fileInspector.readFile('.gitignore');
     const parsedGitignore = parseGitignore(content);
 
-    // lockfiles
-    const packageJsonRegex = parsedGitignore.find((value: string) => /package-lock\.json/.test(value));
-    const yarnLockRegex = parsedGitignore.find((value: string) => /yarn\.lock/.test(value));
     // node_modules
     const nodeModulesRegex = parsedGitignore.find((value: string) => /node_modules/.test(value));
     // misc
     const coverageRegex = parsedGitignore.find((value: string) => /coverage/.test(value));
     const errorLogRegex = parsedGitignore.find((value: string) => /\.log/.test(value));
 
-    if ((packageJsonRegex || yarnLockRegex) && nodeModulesRegex && errorLogRegex && coverageRegex) {
+    if (nodeModulesRegex && errorLogRegex && coverageRegex) {
       return PracticeEvaluationResult.practicing;
     }
 

--- a/src/practices/TypeScript/TsGitignoreCorrectlySetPractice.spec.ts
+++ b/src/practices/TypeScript/TsGitignoreCorrectlySetPractice.spec.ts
@@ -3,6 +3,13 @@ import { gitignoreContent } from '../../detectors/__MOCKS__/JavaScript/gitignore
 import { PracticeEvaluationResult } from '../../model';
 import { TestContainerContext, createTestContainer } from '../../inversify.config';
 
+const basicGitignore = `
+build
+node_modules
+coverage
+.log
+`;
+
 describe('TsGitignoreCorrectlySetPractice', () => {
   let practice: TsGitignoreCorrectlySetPractice;
   let containerCtx: TestContainerContext;
@@ -39,5 +46,32 @@ describe('TsGitignoreCorrectlySetPractice', () => {
   it('Returns unknown if there is no fileInspector', async () => {
     const evaluated = await practice.evaluate({ ...containerCtx.practiceContext, ...{ root: { fileInspector: undefined } } });
     expect(evaluated).toEqual(PracticeEvaluationResult.unknown);
+  });
+
+  it('Returns practicing if there are no lockfiles in .gitignore', async () => {
+    containerCtx.virtualFileSystemService.setFileSystem({
+      '.gitignore': basicGitignore,
+    });
+
+    const evaluated = await practice.evaluate(containerCtx.practiceContext);
+    expect(evaluated).toEqual(PracticeEvaluationResult.practicing);
+  });
+
+  it('Returns practicing if there is only one lockfile in .gitignore', async () => {
+    containerCtx.virtualFileSystemService.setFileSystem({
+      '.gitignore': `${basicGitignore}\nyarn.lock`,
+    });
+
+    const evaluated = await practice.evaluate(containerCtx.practiceContext);
+    expect(evaluated).toEqual(PracticeEvaluationResult.practicing);
+  });
+
+  it('Returns notPracticing if there are both lockfiles in .gitignore', async () => {
+    containerCtx.virtualFileSystemService.setFileSystem({
+      '.gitignore': `${basicGitignore}\nyarn.lock\npackage-lock.json`,
+    });
+
+    const evaluated = await practice.evaluate(containerCtx.practiceContext);
+    expect(evaluated).toEqual(PracticeEvaluationResult.notPracticing);
   });
 });

--- a/src/practices/TypeScript/TsGitignoreCorrectlySetPractice.spec.ts
+++ b/src/practices/TypeScript/TsGitignoreCorrectlySetPractice.spec.ts
@@ -48,13 +48,13 @@ describe('TsGitignoreCorrectlySetPractice', () => {
     expect(evaluated).toEqual(PracticeEvaluationResult.unknown);
   });
 
-  it('Returns practicing if there are no lockfiles in .gitignore', async () => {
+  it('Returns notPracticing if there are no lockfiles in .gitignore', async () => {
     containerCtx.virtualFileSystemService.setFileSystem({
       '.gitignore': basicGitignore,
     });
 
     const evaluated = await practice.evaluate(containerCtx.practiceContext);
-    expect(evaluated).toEqual(PracticeEvaluationResult.practicing);
+    expect(evaluated).toEqual(PracticeEvaluationResult.notPracticing);
   });
 
   it('Returns practicing if there is only one lockfile in .gitignore', async () => {

--- a/src/practices/TypeScript/TsGitignoreCorrectlySetPractice.ts
+++ b/src/practices/TypeScript/TsGitignoreCorrectlySetPractice.ts
@@ -35,13 +35,22 @@ export class TsGitignoreCorrectlySetPractice implements IPractice {
     const buildRegex = parsedGitignore.find((value: string) => /build/.test(value));
     const libRegex = parsedGitignore.find((value: string) => /lib/.test(value));
     const distRegex = parsedGitignore.find((value: string) => /dist/.test(value));
+    // lockfiles
+    const packageJsonRegex = parsedGitignore.find((value: string) => /package-lock\.json/.test(value));
+    const yarnLockRegex = parsedGitignore.find((value: string) => /yarn\.lock/.test(value));
     // node_modules
     const nodeModulesRegex = parsedGitignore.find((value: string) => /node_modules/.test(value));
     // misc
     const coverageRegex = parsedGitignore.find((value: string) => /coverage/.test(value));
     const errorLogRegex = parsedGitignore.find((value: string) => /\.log/.test(value));
 
-    if ((buildRegex || libRegex || distRegex) && nodeModulesRegex && errorLogRegex && coverageRegex) {
+    if (
+      (buildRegex || libRegex || distRegex) &&
+      !(packageJsonRegex && yarnLockRegex) &&
+      nodeModulesRegex &&
+      errorLogRegex &&
+      coverageRegex
+    ) {
       return PracticeEvaluationResult.practicing;
     }
 

--- a/src/practices/TypeScript/TsGitignoreCorrectlySetPractice.ts
+++ b/src/practices/TypeScript/TsGitignoreCorrectlySetPractice.ts
@@ -35,22 +35,13 @@ export class TsGitignoreCorrectlySetPractice implements IPractice {
     const buildRegex = parsedGitignore.find((value: string) => /build/.test(value));
     const libRegex = parsedGitignore.find((value: string) => /lib/.test(value));
     const distRegex = parsedGitignore.find((value: string) => /dist/.test(value));
-    // lockfiles
-    const packageJsonRegex = parsedGitignore.find((value: string) => /package-lock\.json/.test(value));
-    const yarnLockRegex = parsedGitignore.find((value: string) => /yarn\.lock/.test(value));
     // node_modules
     const nodeModulesRegex = parsedGitignore.find((value: string) => /node_modules/.test(value));
     // misc
     const coverageRegex = parsedGitignore.find((value: string) => /coverage/.test(value));
     const errorLogRegex = parsedGitignore.find((value: string) => /\.log/.test(value));
 
-    if (
-      (buildRegex || libRegex || distRegex) &&
-      (packageJsonRegex || yarnLockRegex) &&
-      nodeModulesRegex &&
-      errorLogRegex &&
-      coverageRegex
-    ) {
+    if ((buildRegex || libRegex || distRegex) && nodeModulesRegex && errorLogRegex && coverageRegex) {
       return PracticeEvaluationResult.practicing;
     }
 

--- a/src/practices/TypeScript/TsGitignoreCorrectlySetPractice.ts
+++ b/src/practices/TypeScript/TsGitignoreCorrectlySetPractice.ts
@@ -44,13 +44,9 @@ export class TsGitignoreCorrectlySetPractice implements IPractice {
     const coverageRegex = parsedGitignore.find((value: string) => /coverage/.test(value));
     const errorLogRegex = parsedGitignore.find((value: string) => /\.log/.test(value));
 
-    if (
-      (buildRegex || libRegex || distRegex) &&
-      !(packageJsonRegex && yarnLockRegex) &&
-      nodeModulesRegex &&
-      errorLogRegex &&
-      coverageRegex
-    ) {
+    const exactlyOneLockfile = (packageJsonRegex && !yarnLockRegex) || (!packageJsonRegex && yarnLockRegex);
+
+    if ((buildRegex || libRegex || distRegex) && exactlyOneLockfile && nodeModulesRegex && errorLogRegex && coverageRegex) {
       return PracticeEvaluationResult.practicing;
     }
 


### PR DESCRIPTION
As mentioned in [npm](https://docs.npmjs.com/files/package-locks#using-locked-packages) and [yarn](https://yarnpkg.com/en/docs/yarn-lock#toc-check-into-source-control) docs, adding lockfile to VCS might be perfectly valid option

Resolves #96 