### PR TITLE
fix(core): load default Command from oclif

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,37 @@
+# [2.0.0-pre-list-practices.1](https://github.com/dxheroes/dx-scanner/compare/v1.38.0...v2.0.0-pre-list-practices.1) (2020-01-28)
+
+
+### Bug Fixes
+
+* **core:** load default Command from oclif ([46af21c](https://github.com/dxheroes/dx-scanner/commit/46af21caad8e586411a7e939d172cd4dfa50bcf5))
+* allow fail and recursive to be optional ([457eb72](https://github.com/dxheroes/dx-scanner/commit/457eb72426d4f4ccca135f43e599ea577c4f0077))
+* inform user if the config file already exists ([569725a](https://github.com/dxheroes/dx-scanner/commit/569725a0e30acb8d03523b70da9db981188d5023))
+* parse flags with init subcommand ([3ede8e0](https://github.com/dxheroes/dx-scanner/commit/3ede8e0fd3f02078d91ca85e58d2068bd0d9cf11))
+* remove comments a comment ideas ([e604238](https://github.com/dxheroes/dx-scanner/commit/e6042385ab862fac7ea888d155ed23189b5e61eb))
+* remove unnecessary code ([bb88dd4](https://github.com/dxheroes/dx-scanner/commit/bb88dd4bd3ab615cd5a9989f63f18c4dc69977ad))
+* remove unused commented code and import reflect-metadata ([5ad591a](https://github.com/dxheroes/dx-scanner/commit/5ad591a5d7ffafbc527643d202077c06085a7b6b))
+* remove unused flag, aliases and set new examples ([cccdf57](https://github.com/dxheroes/dx-scanner/commit/cccdf574f080db6039cd91f302774f6d6c4159ae))
+* rename method ([d8a88cf](https://github.com/dxheroes/dx-scanner/commit/d8a88cfbcabaffb0a8dd48e102e0e91d6c4c24f2))
+* rename subcommand ([e939b9e](https://github.com/dxheroes/dx-scanner/commit/e939b9e1f26b7bd14f6bc79ac34a9e67292a21bd))
+* revert change ([b4b6497](https://github.com/dxheroes/dx-scanner/commit/b4b6497f2909aa1bbfd45129883af5e4afadb8da))
+* set arguments back to be required ([dc8edd6](https://github.com/dxheroes/dx-scanner/commit/dc8edd602f81da53bb14d3891a4c1f73824338ac))
+* typo ([19e8bd1](https://github.com/dxheroes/dx-scanner/commit/19e8bd1ecbe785d1c6e47b2e91160742654e101c))
+
+
+### Features
+
+* **core:** CLI changed to multi-command ([cbf03b0](https://github.com/dxheroes/dx-scanner/commit/cbf03b016d6569c10638c9177a96cfaa962dcc77))
+* add two subcommands ([9661d6b](https://github.com/dxheroes/dx-scanner/commit/9661d6b40f348cc66cef7b64fa033e65e851c935))
+* convert init flag to subcommand ([9594d3a](https://github.com/dxheroes/dx-scanner/commit/9594d3ae7183d95eca7de2a68784bde27d4084bd))
+* implement method to get practices ([871f7f2](https://github.com/dxheroes/dx-scanner/commit/871f7f2bb3ca950c6313afc8b04baed3f2aa3301))
+* list practices in a table ([9d8a8f6](https://github.com/dxheroes/dx-scanner/commit/9d8a8f69b0f88f41052e46bd485a6d3c9abd97a1))
+* wip - add subcommand ([6c33fc4](https://github.com/dxheroes/dx-scanner/commit/6c33fc4f7fa4761cbbdd00a4a1f668f7aaabb572))
+
+
+### BREAKING CHANGES
+
+* **core:** now exists commands such as init, practices and run
+
 # [1.38.0](https://github.com/dxheroes/dx-scanner/compare/v1.37.1...v1.38.0) (2020-01-27)
 
 

--- a/bin/run
+++ b/bin/run
@@ -11,7 +11,6 @@ if (dev) {
   console.warn("WARNING: You're running DX Scanner in development mode.")
 }
 
-require(`../${dev ? 'src' : 'lib'}`)
-  .run()
+require('@oclif/command').run()
   .then(require('@oclif/command/flush'))
   .catch(require('@oclif/errors/handle'));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dx-scanner",
   "description": "Scan your project for possible DX recommendations.",
-  "version": "1.38.0",
+  "version": "2.0.0-pre-list-practices.1",
   "author": "DX Heroes LTD <info@dxheroes.io> (https://dxheroes.io)",
   "homepage": "https://github.com/dxheroes/dx-scanner",
   "repository": "ssh://git@github.com/dxheroes/dx-scanner.git",

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import { Command, flags } from '@oclif/command';
 import { createRootContainer } from '../inversify.config';
 import { Scanner } from '../scanner';

--- a/src/commands/practices.ts
+++ b/src/commands/practices.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import { Command, flags } from '@oclif/command';
 import { createRootContainer } from '../inversify.config';
 import { Scanner } from '../scanner';

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-process-env */
+import 'reflect-metadata';
 import { Command, flags } from '@oclif/command';
 import cli from 'cli-ux';
 import debug from 'debug';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,1 @@
 export { run } from '@oclif/command';
-import 'reflect-metadata';


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
The DX Scanner doesn't work globally installed from npm.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It fixes globally installed dx-scanner.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
