### PR TITLE
fix: adjusting practices & inspector for gradle/kotlin variation

### DIFF
--- a/src/detectors/Java/JavaLanguageDetector.spec.ts
+++ b/src/detectors/Java/JavaLanguageDetector.spec.ts
@@ -46,6 +46,19 @@ describe('JavaLanguageDetector', () => {
     expect(langAtPath[0].path).toEqual(nodePath.sep);
   });
 
+  it('detects kotlin correctly via build.gradle.kts', async () => {
+    const structure: DirectoryJSON = {
+      '/build.gradle.kts': '...',
+    };
+
+    virtualFileSystemService.setFileSystem(structure);
+
+    const langAtPath = await detector.detectLanguage();
+    expect(langAtPath.length).toEqual(1);
+    expect(langAtPath[0].language).toEqual(ProgrammingLanguage.Kotlin);
+    expect(langAtPath[0].path).toEqual(nodePath.sep);
+  });
+
   it('detects java correctly via java extension', async () => {
     const structure: DirectoryJSON = {
       '/*.java': '...',

--- a/src/inspectors/package/JavaPackageInspector.ts
+++ b/src/inspectors/package/JavaPackageInspector.ts
@@ -26,10 +26,17 @@ export class JavaPackageInspector extends PackageInspectorBase {
         await this.resolveMavenFileString(mavenFileString);
       } else {
         const isGradle: boolean = await this.fileInspector.exists('build.gradle');
+        let isGradleKts = false;
         if (!isGradle) {
-          throw ErrorFactory.newInternalError('Unsupported Java project architecture');
+          if (await this.fileInspector.exists('build.gradle.kts')) {
+            isGradleKts = true;
+          } else {
+            throw ErrorFactory.newInternalError('Unsupported Java project architecture');
+          }
         }
-        const gradleFileString = await this.fileInspector.readFile('build.gradle');
+        const gradleFileString = isGradleKts
+          ? await this.fileInspector.readFile('build.gradle.kts')
+          : await this.fileInspector.readFile('build.gradle');
         await this.resolveGradleFileString(gradleFileString);
       }
       this.addPackages(this.parsedDependencies, DependencyType.Runtime);

--- a/src/inspectors/package/JavaPackageInspectorGradle.spec.ts
+++ b/src/inspectors/package/JavaPackageInspectorGradle.spec.ts
@@ -64,6 +64,15 @@ describe('JavaPackageInspector Gradle', () => {
         await inspector.init();
         expect(inspector.hasPackageManagement()).toBe(true);
       });
+
+      it('returns true if build.gradle.kts is valid and present', async () => {
+        containerCtx.virtualFileSystemService.clearFileSystem();
+        containerCtx.virtualFileSystemService.setFileSystem({
+          'build.gradle.kts': buildGRADLEContents,
+        });
+        await inspector.init();
+        expect(inspector.hasPackageManagement()).toBe(true);
+      });
     });
 
     describe('#hasLockFile', () => {

--- a/src/practices/Java/JavaGitignoreCorrectlySetPractice.spec.ts
+++ b/src/practices/Java/JavaGitignoreCorrectlySetPractice.spec.ts
@@ -40,6 +40,16 @@ describe('JavaGitignoreCorrectlySetPractice', () => {
     expect(evaluated).toEqual(PracticeEvaluationResult.practicing);
   });
 
+  it('Returns practicing if the .gitignore is set correctly for Kotlin/GRADLE', async () => {
+    containerCtx.virtualFileSystemService.setFileSystem({
+      '.gitignore': gitignoreContent,
+      'build.gradle.kts': buildGRADLEContents,
+    });
+
+    const evaluated = await practice.evaluate(containerCtx.practiceContext);
+    expect(evaluated).toEqual(PracticeEvaluationResult.practicing);
+  });
+
   it('Returns notPracticing if there the .gitignore is NOT set correctly', async () => {
     containerCtx.virtualFileSystemService.setFileSystem({
       '.gitignore': '...',
@@ -68,7 +78,21 @@ describe('JavaGitignoreCorrectlySetPractice', () => {
     expect(evaluated).toEqual(PracticeEvaluationResult.unknown);
   });
 
-  it('Returns unknown if there is *.class, *.log, *.jar, *.war in .gitignore but not correctly set for build.gradle', async () => {
+  it('Returns unknown if there is *.class, *.log, *.jar, *.war in .gitignore but not correctly set for build.gradle.kts', async () => {
+    containerCtx.virtualFileSystemService.setFileSystem({
+      '.gitignore': `
+      *.class
+      *.log
+      *.jar
+      *.war`,
+      'build.gradle.kts': buildGRADLEContents,
+    });
+
+    const evaluated = await practice.evaluate(containerCtx.practiceContext);
+    expect(evaluated).toEqual(PracticeEvaluationResult.unknown);
+  });
+
+  it('Returns unknown if there is *.class, *.log, *.jar, *.war in .gitignore but not correctly set for pom.xml', async () => {
     containerCtx.virtualFileSystemService.setFileSystem({
       '.gitignore': `
       *.class
@@ -82,7 +106,7 @@ describe('JavaGitignoreCorrectlySetPractice', () => {
     expect(evaluated).toEqual(PracticeEvaluationResult.unknown);
   });
 
-  it('Returns unknown if there is correctly set .gitignore, but no pom.xml and build.gradle ', async () => {
+  it('Returns unknown if there is correctly set .gitignore, but no pom.xml and build.gradle or build.gradle.kts', async () => {
     containerCtx.virtualFileSystemService.setFileSystem({
       '.gitignore': gitignoreContent,
     });

--- a/src/practices/Java/JavaGitignoreCorrectlySetPractice.ts
+++ b/src/practices/Java/JavaGitignoreCorrectlySetPractice.ts
@@ -45,7 +45,7 @@ export class JavaGitignoreCorrectlySetPractice implements IPractice {
       if (await this.resolveGitignorePractice(parsedGitignore, 'Maven')) {
         return PracticeEvaluationResult.practicing;
       }
-    } else if (await ctx.fileInspector.exists('build.gradle')) {
+    } else if ((await ctx.fileInspector.exists('build.gradle')) || (await ctx.fileInspector.exists('build.gradle.kts'))) {
       if (await this.resolveGitignorePractice(parsedGitignore, 'Gradle')) {
         return PracticeEvaluationResult.practicing;
       }

--- a/src/practices/Java/JavaNamingConventionsPractice.spec.ts
+++ b/src/practices/Java/JavaNamingConventionsPractice.spec.ts
@@ -106,6 +106,17 @@ describe('JavaPackageManagementUsedPractice', () => {
     expect(evaluated).toEqual(PracticeEvaluationResult.unknown);
   });
 
+  it('Does not evaluate & skips build.gradle.kts file to check other class files', async () => {
+    containerCtx.virtualFileSystemService.setFileSystem({
+      'pom.xml': '...',
+      'build.gradle.kts': '...',
+      'src/main/java/org/vision/root/CronOperations/VeryCorrectNamingConvention.kt': '',
+    });
+
+    const evaluated = await practice.evaluate(containerCtx.practiceContext);
+    expect(evaluated).toEqual(PracticeEvaluationResult.practicing);
+  });
+
   it('Returns unknown if there is no fileInspector', async () => {
     const evaluated = await practice.evaluate({ ...containerCtx.practiceContext, fileInspector: undefined });
     expect(evaluated).toEqual(PracticeEvaluationResult.unknown);

--- a/src/practices/Java/JavaNamingConventionsPractice.ts
+++ b/src/practices/Java/JavaNamingConventionsPractice.ts
@@ -38,9 +38,11 @@ export class JavaNamingConventionsPractice implements IPractice {
     const incorrectFiles = [];
 
     scannedFiles.forEach((file) => {
-      const correctPascalCase = camelCase(file.baseName, { pascalCase: true });
-      if (file.baseName !== correctPascalCase) {
-        incorrectFiles.push(file.baseName);
+      if (file.baseName !== 'build.gradle' && file.baseName !== 'settings.gradle') {
+        const correctPascalCase = camelCase(file.baseName, { pascalCase: true });
+        if (file.baseName !== correctPascalCase) {
+          incorrectFiles.push(file.baseName);
+        }
       }
     });
 

--- a/src/practices/Java/JavaPackageManagementUsedPractice.spec.ts
+++ b/src/practices/Java/JavaPackageManagementUsedPractice.spec.ts
@@ -35,6 +35,14 @@ describe('JavaPackageManagementUsedPractice', () => {
     expect(evaluated).toEqual(PracticeEvaluationResult.practicing);
   });
 
+  it('Returns practicing if there is a build.gradle.kts', async () => {
+    containerCtx.virtualFileSystemService.setFileSystem({
+      'build.gradle.kts': buildGRADLEContents,
+    });
+    const evaluated = await practice.evaluate(containerCtx.practiceContext);
+    expect(evaluated).toEqual(PracticeEvaluationResult.practicing);
+  });
+
   it('Returns notPracticing if there is NO pom.xml or build.gradle', async () => {
     containerCtx.virtualFileSystemService.setFileSystem({
       'not.exists': '...',

--- a/src/practices/Java/JavaPackageManagementUsedPractice.ts
+++ b/src/practices/Java/JavaPackageManagementUsedPractice.ts
@@ -25,6 +25,8 @@ export class JavaPackageManagementUsedPractice implements IPractice {
       return PracticeEvaluationResult.practicing;
     } else if (await ctx.fileInspector.exists('build.gradle')) {
       return PracticeEvaluationResult.practicing;
+    } else if (await ctx.fileInspector.exists('build.gradle.kts')) {
+      return PracticeEvaluationResult.practicing;
     }
 
     return PracticeEvaluationResult.notPracticing;


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
This PR will fix the current Java practices and Inspector to accommodate for the Kotlin/Gradle variation involving `build.gradle.kts`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added new practice to practice list in README.md.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
