### PR TITLE
Use specific imports in ErrorFactory

### DIFF
--- a/src/lib/errors/ErrorFactory.ts
+++ b/src/lib/errors/ErrorFactory.ts
@@ -1,4 +1,5 @@
-import { ServiceError, ErrorCode } from '.';
+import { ErrorCode } from './model';
+import { ServiceError } from './ServiceError';
 
 export class ErrorFactory {
   static newInternalError(message = 'The app went broken. Sorry about that. Not your fault') {


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
Avoid circular dependency in `ErrorFactory.ts`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In current version, there is a circular dependency in `lib/errors/index.ts -> lib/errors/ErrorFactory.ts -> lib/errors/index.ts`. This was OK for some places, where `ErrorFactory` was required directly (e.g. `JSONUtils.ts`) but caused `ErrorFactory` to be just an empty object on places where it was required through `lib/errors/index.ts` (e.g. `ScannerUtils.ts`)

After this change, circular dependency is avoided and requiring `ErrorFactory` via `index.ts` won't result in empty object. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added new practice to practice list in README.md.
- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
