### PR TITLE
fix: running ci mode w/ invalid credentials

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -7,6 +7,7 @@ import { Scanner } from '../scanner';
 import { ScanningStrategyDetectorUtils } from '../detectors/utils/ScanningStrategyDetectorUtils';
 import { ServiceType } from '../detectors';
 import { CLIArgs } from '../model';
+import { ErrorFactory } from '../lib/errors/ErrorFactory';
 
 export default class Run {
   static async run(path = process.cwd(), cmd: CLIArgs) {
@@ -34,6 +35,11 @@ export default class Run {
     const scanner = container.get(Scanner);
 
     let scanResult = await scanner.scan();
+
+    // needsAuth and cmd.ci are both true if the credentials are invalid either due to 401 or 403
+    if (scanResult.needsAuth && cmd.ci) {
+      throw ErrorFactory.newAuthorizationError('Invalid Authorization Credentials!');
+    }
 
     if (scanResult.needsAuth && !cmd.ci) {
       if (scanResult.isOnline) {


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
This PR will solve issue #260 

Old behaviour (silent fail):
```
08:33 $ yarn start run --ci -r -a asdf
yarn run v1.22.0
$ ./bin/run run --ci -r -a asdf
WARNING: You're running DX Scanner in development mode.
Scanning URI: /Users/prokop/Sites/_dxheroes/scanner... done
Scan duration 0s.
✨  Done in 20.76s.
```

New behaviour:
```
/Users/cngng/Documents/Applifting/DX Scanner/dx-scanner/src/lib/errors/ErrorFactory.ts:20
    return new ServiceError({
           ^
ServiceError: Invalid Authorization Credentials!
    at Function.newAuthorizationError (/Users/cngng/Documents/Applifting/DX Scanner/dx-scanner/src/lib/errors/ErrorFactory.ts:20:12)
    at Command.run (/Users/cngng/Documents/Applifting/DX Scanner/dx-scanner/src/commands/run.ts:40:26)
    at processTicksAndRejections (internal/process/task_queues.js:85:5)
    at async Promise.all (index 0)
    at Function.run (/Users/cngng/Documents/Applifting/DX Scanner/dx-scanner/src/index.ts:86:5)
Scanning URI: /Users/cngng/Documents/Applifting/DX Scanner/dx-scanner... done
error Command failed with exit code 1.
```

Reproduced using:
`yarn start run --ci -r -a asdf123456789` and tested against `yarn start run --ci -r -a valid_token`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added new practice to practice list in README.md.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
