### PR TITLE
fix(gitlab): do not reject unauthorized certificates

### DIFF
--- a/src/services/gitlab/gitlabClient/GitLabClient.ts
+++ b/src/services/gitlab/gitlabClient/GitLabClient.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { injectable } from 'inversify';
 import debug from 'debug';
+import https from 'https';
 
 @injectable()
 export class GitLabClient {
@@ -23,6 +24,9 @@ export class GitLabClient {
       baseURL: `${this.host}/api/v4`,
       timeout: this.timeout,
       headers: { ...this.headers },
+      httpsAgent: new https.Agent({
+        rejectUnauthorized: false,
+      }),
     });
   }
 }


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
Do not reject unauthorized certificates in Gitlab Axios.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
DX Scanner can not post a comment in a private Gitlab instance with a custom SSL certificate.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have added new practice to practice list in README.md.
- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
