### PR TITLE
Fixer for Prettier present

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "jest-mock-extended": "1.0.8",
     "nock": "12.0.3",
     "prettier": "1.19.1",
+    "prettier-default-config": "^0.2.3",
     "rimraf": "3.0.2",
     "semantic-release": "17.0.4",
     "semantic-release-slack-bot": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "jest-mock-extended": "1.0.8",
     "nock": "12.0.3",
     "prettier": "1.19.1",
-    "prettier-default-config": "^0.2.3",
+    "prettier-default-config": "0.2.3",
     "rimraf": "3.0.2",
     "semantic-release": "17.0.4",
     "semantic-release-slack-bot": "1.6.1",

--- a/src/inspectors/FileInspector.ts
+++ b/src/inspectors/FileInspector.ts
@@ -46,9 +46,9 @@ export class FileInspector implements IFileInspector {
     });
   }
 
-  createFile(path: string, data: string) {
+  writeFile(path: string, data: string) {
     if (this.projectFilesBrowser instanceof FileSystemService) {
-      return this.projectFilesBrowser.createFile(this.normalizePath(path), data);
+      return this.projectFilesBrowser.writeFile(this.normalizePath(path), data);
     }
     return Promise.resolve();
   }

--- a/src/inspectors/IFileInspector.ts
+++ b/src/inspectors/IFileInspector.ts
@@ -5,7 +5,7 @@ export interface IFileInspector {
   exists(path: string): Promise<boolean>;
   readDirectory(path: string): Promise<string[]>;
   readFile(path: string): Promise<string>;
-  createFile(path: string, data: string): Promise<void>;
+  writeFile(path: string, data: string): Promise<void>;
   isFile(path: string): Promise<boolean>;
   isDirectory(path: string): Promise<boolean>;
   getMetadata(path: string): Promise<Metadata>;

--- a/src/practices/JavaScript/PrettierUsedPractice.spec.ts
+++ b/src/practices/JavaScript/PrettierUsedPractice.spec.ts
@@ -65,6 +65,7 @@ describe('PrettierUsedPractice', () => {
   describe('Fixer', () => {
     afterEach(async () => {
       jest.clearAllMocks();
+      containerCtx.virtualFileSystemService.clearFileSystem();
     });
 
     it('Install prettier package', async () => {

--- a/src/practices/JavaScript/PrettierUsedPractice.spec.ts
+++ b/src/practices/JavaScript/PrettierUsedPractice.spec.ts
@@ -2,6 +2,13 @@ import { PrettierUsedPractice } from './PrettierUsedPractice';
 import { PracticeEvaluationResult, ProgrammingLanguage } from '../../model';
 import { TestContainerContext, createTestContainer } from '../../inversify.config';
 import { IPackageInspector } from '../../inspectors/IPackageInspector';
+import { JavaScriptPackageInspector } from '../../inspectors';
+import { Types } from '../../types';
+import shelljs from 'shelljs';
+
+jest.mock('shelljs', () => ({
+  exec: jest.fn(),
+}));
 
 describe('PrettierUsedPractice', () => {
   let practice: PrettierUsedPractice;
@@ -53,5 +60,45 @@ describe('PrettierUsedPractice', () => {
 
     const result = await practice.isApplicable(containerCtx.practiceContext);
     expect(result).toEqual(false);
+  });
+
+  describe('Fixer', () => {
+    afterEach(async () => {
+      jest.clearAllMocks();
+    });
+
+    it('Install prettier package', async () => {
+      containerCtx.virtualFileSystemService.setFileSystem({
+        'package.json': '{}',
+        'package-lock.json': '',
+      });
+
+      (shelljs.exec as jest.Mock).mockImplementation();
+      await practice.fix(containerCtx.fixerContext);
+
+      expect((shelljs.exec as jest.Mock).mock.calls[0][0]).toContain('prettier');
+    });
+    it('Creates prettier config file', async () => {
+      containerCtx.virtualFileSystemService.setFileSystem({
+        'package.json': '{}',
+        'package-lock.json': '',
+      });
+
+      await practice.fix(containerCtx.fixerContext);
+
+      const exists = await containerCtx.virtualFileSystemService.exists('.prettierrc');
+      expect(exists).toBe(true);
+    });
+    it('Add prettier script', async () => {
+      containerCtx.virtualFileSystemService.setFileSystem({
+        'package.json': '{}',
+        'package-lock.json': '',
+      });
+
+      await practice.fix(containerCtx.fixerContext);
+
+      const newPackageJson = await containerCtx.virtualFileSystemService.readFile('package.json');
+      expect(newPackageJson).toContain('format');
+    });
   });
 });

--- a/src/practices/JavaScript/PrettierUsedPractice.ts
+++ b/src/practices/JavaScript/PrettierUsedPractice.ts
@@ -2,6 +2,10 @@ import { IPractice } from '../IPractice';
 import { PracticeEvaluationResult, PracticeImpact, ProgrammingLanguage } from '../../model';
 import { DxPractice } from '../DxPracticeDecorator';
 import { PracticeContext } from '../../contexts/practice/PracticeContext';
+import { PackageManagerUtils } from '../utils/PackageManagerUtils';
+import { defaultConfigFor } from 'prettier-default-config';
+import { FixerContext } from '../../contexts/fixer/FixerContext';
+import { IFileInspector } from '../../inspectors';
 
 @DxPractice({
   id: 'JavaScript.PrettierUsed',
@@ -28,5 +32,38 @@ export class PrettierUsedPractice implements IPractice {
       }
     }
     return PracticeEvaluationResult.unknown;
+  }
+
+  async fix(ctx: FixerContext) {
+    const inspector = ctx.fileInspector?.basePath ? ctx.fileInspector : ctx.root.fileInspector;
+    if (!inspector) return;
+    // install prettier
+    await PackageManagerUtils.installPackage(inspector, 'prettier', { dev: true });
+    // create default config
+    const prettierConfigPresent = async (inspector: IFileInspector) => {
+      const checks = await Promise.all(
+        [
+          '.prettierrc',
+          '.prettierrc.json',
+          '.prettierrc.yaml',
+          '.prettierrc.yml',
+          '.prettierrc.js',
+          'prettier.config.js',
+          '.prettierrc.toml',
+        ].map((name) => inspector.exists(name)),
+      );
+      return checks.some(Boolean);
+    };
+    if (!(await prettierConfigPresent(inspector))) {
+      const prettierConfig = JSON.stringify(defaultConfigFor('json'), null, 2);
+      await inspector.writeFile('.prettierrc', prettierConfig);
+    }
+    // add npm script
+    const packageJsonString = await inspector.readFile('package.json');
+    const packageJson = JSON.parse(packageJsonString);
+    if (!Object.keys(packageJson.scripts).includes('format')) {
+      packageJson.scripts.format = 'prettier';
+      await inspector.writeFile('package.json', `${JSON.stringify(packageJson, null, 2)}\n`);
+    }
   }
 }

--- a/src/practices/JavaScript/PrettierUsedPractice.ts
+++ b/src/practices/JavaScript/PrettierUsedPractice.ts
@@ -62,7 +62,7 @@ export class PrettierUsedPractice implements IPractice {
     const packageJsonString = await inspector.readFile('package.json');
     const packageJson = JSON.parse(packageJsonString);
     if (!Object.keys(packageJson.scripts).includes('format')) {
-      packageJson.scripts.format = 'prettier';
+      packageJson.scripts.format = 'prettier --check "**/*.js"';
       await inspector.writeFile('package.json', `${JSON.stringify(packageJson, null, 2)}\n`);
     }
   }

--- a/src/practices/JavaScript/PrettierUsedPractice.ts
+++ b/src/practices/JavaScript/PrettierUsedPractice.ts
@@ -61,6 +61,7 @@ export class PrettierUsedPractice implements IPractice {
     // add npm script
     const packageJsonString = await inspector.readFile('package.json');
     const packageJson = JSON.parse(packageJsonString);
+    if (!packageJson.scripts) packageJson.scripts = {};
     if (!Object.keys(packageJson.scripts).includes('format')) {
       packageJson.scripts.format = 'prettier --check "**/*.js"';
       await inspector.writeFile('package.json', `${JSON.stringify(packageJson, null, 2)}\n`);

--- a/src/practices/LanguageIndependent/EditorConfigIsPresentPractice.ts
+++ b/src/practices/LanguageIndependent/EditorConfigIsPresentPractice.ts
@@ -49,9 +49,9 @@ export class EditorConfigIsPresentPractice implements IPractice {
 
   async fix(ctx: FixerContext) {
     if (ctx.fileInspector?.basePath) {
-      await ctx.fileInspector.createFile('.editorconfig', editorConfigTemplate);
+      await ctx.fileInspector.writeFile('.editorconfig', editorConfigTemplate);
     } else {
-      await ctx.root.fileInspector?.createFile('.editorconfig', editorConfigTemplate);
+      await ctx.root.fileInspector?.writeFile('.editorconfig', editorConfigTemplate);
     }
     ctx.fileInspector?.purgeCache();
     ctx.root.fileInspector?.purgeCache();

--- a/src/practices/utils/PackageManagerUtils.ts
+++ b/src/practices/utils/PackageManagerUtils.ts
@@ -1,5 +1,6 @@
 import { sync as commandExistsSync } from 'command-exists';
 import { IFileInspector } from '../../inspectors';
+import shell from 'shelljs';
 
 export class PackageManagerUtils {
   /** Guess the package manager by lockfiles and shrinkfile */
@@ -36,6 +37,15 @@ export class PackageManagerUtils {
   static getPackageManagerInstalled = async (fileInspector?: IFileInspector) => {
     const pm = await PackageManagerUtils.getPackageManager(fileInspector);
     return PackageManagerUtils.packageManagerInstalled(pm);
+  };
+
+  static installPackage = async (fileInspector: IFileInspector, packageName: string, options: { dev: boolean } = { dev: false }) => {
+    const pm = await PackageManagerUtils.getPackageManagerInstalled(fileInspector);
+    if (pm === PackageManagerType.npm) {
+      shell.exec(`npm i ${options.dev ? '-D' : ''} --prefix ${fileInspector.basePath} ${packageName}`);
+    } else if (pm === PackageManagerType.yarn) {
+      shell.exec(`yarn add ${options.dev ? '-D' : ''} --cwd ${fileInspector.basePath} ${packageName}`);
+    }
   };
 }
 

--- a/types/prettier-default-config/index.d.ts
+++ b/types/prettier-default-config/index.d.ts
@@ -1,0 +1,4 @@
+declare module 'prettier-default-config' {
+  export function defaultConfigFor(format: string): { [key: string]: string };
+  export const formats: { [key: string]: { filename: string; generate: () => string } };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -228,6 +228,11 @@
     update-notifier "^2.2.0"
     yargs "^8.0.2"
 
+"@iarna/toml@^2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.3.tgz#f060bf6eaafae4d56a7dac618980838b0696e2ab"
+  integrity sha512-FmuxfCuolpLl0AnQ2NHSzoUKWEJDFl63qXjzdoWBVyFCXzMGm1spBzk7LeHNoVCiWCF7mRVms9e6jEV9+MoPbg==
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz#10602de5570baea82f8afbfa2630b24e7a8cfe5b"
@@ -7780,6 +7785,16 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
+prettier-default-config@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/prettier-default-config/-/prettier-default-config-0.2.3.tgz#9fb44bba4ab910cfde921627228d0167397e8071"
+  integrity sha512-Rulfu+YXrWWl29lFezGr+jFkuyATxHEaElPQutZAs0zuSXwticV3p6fvQCqBHUnPN0V84Id1GqBJy3ByiJ4/VQ==
+  dependencies:
+    "@iarna/toml" "^2.2.3"
+    minimist "^1.2.0"
+    prettier "^1.19.1"
+    yaml "^1.7.2"
+
 prettier-linter-helpers@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
@@ -7787,7 +7802,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@1.19.1:
+prettier@1.19.1, prettier@^1.19.1:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7785,7 +7785,7 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
-prettier-default-config@^0.2.3:
+prettier-default-config@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/prettier-default-config/-/prettier-default-config-0.2.3.tgz#9fb44bba4ab910cfde921627228d0167397e8071"
   integrity sha512-Rulfu+YXrWWl29lFezGr+jFkuyATxHEaElPQutZAs0zuSXwticV3p6fvQCqBHUnPN0V84Id1GqBJy3ByiJ4/VQ==


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
Add fixer for JavaScript.PrettierUsed practice.
It will:
- install prettier
- if not present, create prettier config with default prettier values
- if not present, add "format" npm script to package.json which runs the prettier

## Caveats
- default values in config are from prettier of DXS, not prettier which is installed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added new practice to practice list in README.md.
- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## TODO:
PackageManagerUtils code looks like it should be part of JavascriptPackageInspector - I want to move it there right after this MR