### PR TITLE
Better GitLab detection from more API endpoints

### DIFF
--- a/src/detectors/ScanningStrategyDetector.spec.ts
+++ b/src/detectors/ScanningStrategyDetector.spec.ts
@@ -250,7 +250,7 @@ describe('ScanningStrategyDetector', () => {
       });
     });
 
-    it('remote private GitLab without protocol in the URL', async () => {
+    it('remote private GitLab without protocol in the URL with valid credentials', async () => {
       const repoPath = 'gitlab.com/DXHeroes/dx-scanner.git';
       const nock = new GitLabNock('DXHeroes', 'dx-scanner', 'gitlab.com');
       nock.listProjects();

--- a/src/detectors/ScanningStrategyDetector.spec.ts
+++ b/src/detectors/ScanningStrategyDetector.spec.ts
@@ -278,7 +278,7 @@ describe('ScanningStrategyDetector', () => {
       nock.checkVersion().reply(403);
       nock.getRepoResponse(403);
 
-      const scanningStrategyDetector = await createScanningStrategyDetector({ uri: repoPath, auth: 'valid_token' });
+      const scanningStrategyDetector = await createScanningStrategyDetector({ uri: repoPath, auth: 'invalid_token' });
       const result = await scanningStrategyDetector.detect();
 
       expect(result).toEqual({

--- a/src/detectors/ScanningStrategyDetector.spec.ts
+++ b/src/detectors/ScanningStrategyDetector.spec.ts
@@ -8,6 +8,7 @@ import { GitLabService } from '../services/gitlab/GitLabService';
 import { argumentsProviderFactory } from '../test/factories/ArgumentsProviderFactory';
 import { ArgumentsProvider } from '../scanner';
 import { ServiceType, AccessType } from './IScanningStrategy';
+import { GitLabNock } from '../test/helpers/gitLabNock';
 jest.mock('simple-git/promise');
 
 describe('ScanningStrategyDetector', () => {
@@ -246,6 +247,46 @@ describe('ScanningStrategyDetector', () => {
         remoteUrl: `https://${repoPath}`,
         isOnline: true,
         serviceType: ServiceType.github,
+      });
+    });
+
+    it('remote private GitLab without protocol in the URL', async () => {
+      const repoPath = 'gitlab.com/DXHeroes/dx-scanner.git';
+      const nock = new GitLabNock('DXHeroes', 'dx-scanner', 'gitlab.com');
+      nock.listProjects();
+      nock.listGroups();
+      nock.checkVersion();
+      nock.getRepoResponse(200, { visibility: 'private' });
+
+      const scanningStrategyDetector = await createScanningStrategyDetector({ uri: repoPath, auth: 'valid_token' });
+      const result = await scanningStrategyDetector.detect();
+
+      expect(result).toEqual({
+        accessType: AccessType.private,
+        localPath: undefined,
+        remoteUrl: `https://${repoPath}`,
+        isOnline: true,
+        serviceType: ServiceType.gitlab,
+      });
+    });
+
+    it('remote private GitLab without protocol in the URL', async () => {
+      const repoPath = 'gitlab.com/DXHeroes/dx-scanner.git';
+      const nock = new GitLabNock('DXHeroes', 'dx-scanner', 'gitlab.com');
+      nock.listProjects();
+      nock.listGroups();
+      nock.checkVersion().reply(403);
+      nock.getRepoResponse(403);
+
+      const scanningStrategyDetector = await createScanningStrategyDetector({ uri: repoPath, auth: 'valid_token' });
+      const result = await scanningStrategyDetector.detect();
+
+      expect(result).toEqual({
+        accessType: AccessType.unknown,
+        localPath: undefined,
+        remoteUrl: `https://${repoPath}`,
+        isOnline: true,
+        serviceType: ServiceType.gitlab,
       });
     });
 

--- a/src/detectors/ScanningStrategyDetector.spec.ts
+++ b/src/detectors/ScanningStrategyDetector.spec.ts
@@ -270,7 +270,7 @@ describe('ScanningStrategyDetector', () => {
       });
     });
 
-    it('remote private GitLab without protocol in the URL', async () => {
+    it('remote private GitLab without protocol in the URL with invalid credentials', async () => {
       const repoPath = 'gitlab.com/DXHeroes/dx-scanner.git';
       const nock = new GitLabNock('DXHeroes', 'dx-scanner', 'gitlab.com');
       nock.listProjects();

--- a/src/detectors/ScanningStrategyDetector.ts
+++ b/src/detectors/ScanningStrategyDetector.ts
@@ -152,6 +152,7 @@ export class ScanningStrategyDetector implements IDetector<string, ScanningStrat
         }
       } catch (error) {
         this.d(error.message);
+        console.log(error.message);
 
         if (!error.response) {
           this.isOnline = false;

--- a/src/detectors/ScanningStrategyDetector.ts
+++ b/src/detectors/ScanningStrategyDetector.ts
@@ -152,7 +152,6 @@ export class ScanningStrategyDetector implements IDetector<string, ScanningStrat
         }
       } catch (error) {
         this.d(error.message);
-        console.log(error.message);
 
         if (!error.response) {
           this.isOnline = false;

--- a/src/detectors/ScanningStrategyDetector.ts
+++ b/src/detectors/ScanningStrategyDetector.ts
@@ -177,10 +177,12 @@ export class ScanningStrategyDetector implements IDetector<string, ScanningStrat
     try {
       await this.gitLabService.listRepos();
       await this.gitLabService.listGroups();
-    } catch (error) {
       serviceType = ServiceType.gitlab;
+    } catch (error) {
+      return undefined;
     }
 
+    // second check to ensure that it is really a GitLab API
     try {
       const response = await this.gitLabService.checkVersion();
       if (has(response, 'version') && has(response, 'revision')) {

--- a/src/detectors/ScanningStrategyDetector.ts
+++ b/src/detectors/ScanningStrategyDetector.ts
@@ -172,6 +172,15 @@ export class ScanningStrategyDetector implements IDetector<string, ScanningStrat
   };
 
   private determineGitLabRemoteServiceType = async (): Promise<ServiceType | undefined> => {
+    let serviceType = undefined;
+
+    try {
+      await this.gitLabService.listRepos();
+      await this.gitLabService.listGroups();
+    } catch (error) {
+      serviceType = ServiceType.gitlab;
+    }
+
     try {
       const response = await this.gitLabService.checkVersion();
       if (has(response, 'version') && has(response, 'revision')) {
@@ -183,11 +192,11 @@ export class ScanningStrategyDetector implements IDetector<string, ScanningStrat
       if (error.response?.status === 401 || error.response?.status === 403) {
         // return undefined if we're not sure that the service is Gitlab
         //  - it prompts user for a credentials
-        return undefined;
+        return serviceType;
       }
-    }
 
-    return undefined;
+      return undefined;
+    }
   };
 }
 

--- a/src/services/gitlab/GitLabService.spec.ts
+++ b/src/services/gitlab/GitLabService.spec.ts
@@ -152,8 +152,8 @@ describe('GitLab Service', () => {
       argumentsProviderFactory({ uri: 'https://git.example.cz/dxheroes/user/repo', auth: 'auth' }),
       repositoryConfig,
     );
-    gitLabNock = new GitLabNock('user', 'repo');
-    gitLabNock.checkVersion(repositoryConfig.host);
+    gitLabNock = new GitLabNock('user', 'repo', repositoryConfig.host);
+    gitLabNock.checkVersion().reply(200, { version: '1.0.0', revision: '225c2e' });
 
     const response = await service.checkVersion();
     expect(response).toMatchObject({ version: '1.0.0', revision: '225c2e' });

--- a/src/services/gitlab/GitLabService.ts
+++ b/src/services/gitlab/GitLabService.ts
@@ -394,6 +394,16 @@ export class GitLabService implements IVCSService {
     };
   }
 
+  async listRepos() {
+    const { data } = await this.unwrap(this.client.Projects.list());
+    return data;
+  }
+
+  async listGroups() {
+    const { data } = await this.unwrap(this.client.Users.listGroups());
+    return data;
+  }
+
   async listContributors(owner: string, repo: string): Promise<Paginated<Contributor>> {
     throw new Error('Method not implemented yet.');
   }

--- a/src/services/gitlab/gitlabClient/resources/Projects.ts
+++ b/src/services/gitlab/gitlabClient/resources/Projects.ts
@@ -13,6 +13,11 @@ export class Projects extends GitLabClient {
     const response: AxiosResponse<Project> = await this.api.get(endpoint);
     return parseResponse(response);
   }
+
+  async list(): Promise<CustomAxiosResponse<Project[]>> {
+    const response = await this.api.get('projects');
+    return parseResponse(response);
+  }
 }
 
 export interface Project {

--- a/src/services/gitlab/gitlabClient/resources/UsersOrGroups.ts
+++ b/src/services/gitlab/gitlabClient/resources/UsersOrGroups.ts
@@ -18,7 +18,12 @@ export class Users extends GitLabClient {
     const endpoint = `groups/${encodeURIComponent(groupName)}`;
 
     // Increase timeout as the request for group info takes longer than the other requests
-    const response = await this.api.get(endpoint, { timeout: 20000 });
+    const response = await this.api.get(endpoint, { timeout: 15000 });
+    return parseResponse(response);
+  }
+
+  async listGroups(): Promise<CustomAxiosResponse<Group[]>> {
+    const response = await this.api.get('groups');
     return parseResponse(response);
   }
 }

--- a/src/test/factories/responses/gitLab/listGroupsResponseFactors.ts
+++ b/src/test/factories/responses/gitLab/listGroupsResponseFactors.ts
@@ -1,0 +1,5 @@
+import { Group } from '../../../../services/gitlab/gitlabClient/resources/UsersOrGroups';
+
+export const gitLabListGroupsResponseFactory = (items: Group[] = []): Group[] => {
+  return items;
+};

--- a/src/test/factories/responses/gitLab/listProjectsResponseFactory.ts
+++ b/src/test/factories/responses/gitLab/listProjectsResponseFactory.ts
@@ -1,0 +1,5 @@
+import { Project } from '../../../../services/gitlab/gitlabClient/resources/Projects';
+
+export const gitLabListProjectsResponseFactory = (items: Project[] = []): Project[] => {
+  return items;
+};

--- a/src/test/helpers/gitLabNock.ts
+++ b/src/test/helpers/gitLabNock.ts
@@ -10,15 +10,19 @@ import { gitLabPullRequestResponseFactory } from '../factories/responses/gitLab/
 import { gitLabRepoCommitsResponseFactory } from '../factories/responses/gitLab/repoCommitResponseFactory';
 import { gitLabRepoInfoResponseFactory } from '../factories/responses/gitLab/repoInfoResponseFactory';
 import { gitLabVersionResponseFactory } from '../factories/responses/gitLab/versionResponseFactory';
+import { gitLabListGroupsResponseFactory } from '../factories/responses/gitLab/listGroupsResponseFactors';
+import { gitLabListProjectsResponseFactory } from '../factories/responses/gitLab/listProjectsResponseFactory';
+import { VersionResponse } from '../../services/gitlab/gitlabClient/resources/Version';
+import { Project } from '../../services/gitlab/gitlabClient/resources/Projects';
 
 export class GitLabNock {
   user: string;
   repoName: string;
   url: string;
 
-  constructor(user: string, repoName: string) {
+  constructor(user: string, repoName: string, host?: string) {
     (this.user = user), (this.repoName = repoName);
-    this.url = 'https://gitlab.com/api/v4';
+    this.url = host ? `https://${host}/api/v4` : 'https://gitlab.com/api/v4';
   }
 
   private pagination = { 'x-total': '1', 'x-next-page': '1', 'x-page': '1', 'x-prev-page': '', 'x-per-page': '1', 'x-total-pages': '1' };
@@ -232,19 +236,32 @@ export class GitLabNock {
     return GitLabNock.get(baseUrl, queryParams).reply(200, [response], this.pagination);
   }
 
-  getRepoResponse() {
+  getRepoResponse(statusCode?: number, project?: Partial<Project>) {
     const encodedProjectUrl = encodeURIComponent(`${this.user}/${this.repoName}`);
 
     const baseUrl = `${this.url}/projects/${encodedProjectUrl}`;
 
-    const response = gitLabRepoInfoResponseFactory();
-    return GitLabNock.get(baseUrl).reply(200, response, this.pagination);
+    const response = gitLabRepoInfoResponseFactory(project);
+    return GitLabNock.get(baseUrl).reply(statusCode || 200, response, this.pagination);
   }
 
-  checkVersion(host: string) {
-    const baseUrl = `https://${host}/api/v4/version`;
-    const response = gitLabVersionResponseFactory();
+  listProjects() {
+    const baseUrl = `${this.url}/projects`;
+    const response = gitLabListProjectsResponseFactory();
 
     return GitLabNock.get(baseUrl).reply(200, response);
+  }
+
+  listGroups() {
+    const baseUrl = `${this.url}/groups`;
+    const response = gitLabListGroupsResponseFactory();
+
+    return GitLabNock.get(baseUrl).reply(200, response);
+  }
+
+  checkVersion() {
+    const baseUrl = `${this.url}/version`;
+
+    return GitLabNock.get(baseUrl);
   }
 }


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If the `/version` endpoints returned 403 because the user didn't provide an API key so the Scan fails with `InternalError: Unable to detect scanning strategy. It seems that the service is not implemented yet.` because it's not sure that the service is GitLab.

Now we call 2 more PUBLIC API endpoints specific for GitLab that can determine the service.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added new practice to practice list in README.md.
- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
