### PR TITLE
Fixer for JsGitignore practice

### DIFF
--- a/src/inspectors/FileInspector.ts
+++ b/src/inspectors/FileInspector.ts
@@ -53,6 +53,13 @@ export class FileInspector implements IFileInspector {
     return Promise.resolve();
   }
 
+  appendFile(path: string, data: string) {
+    if (this.projectFilesBrowser instanceof FileSystemService) {
+      return this.projectFilesBrowser.createFile(this.normalizePath(path), data);
+    }
+    return Promise.resolve();
+  }
+
   isFile(path: string) {
     return this.cache.getOrSet(`${this.basePath}:isFile:${path}`, async () => {
       return this.projectFilesBrowser.isFile(this.normalizePath(path));

--- a/src/inspectors/IFileInspector.ts
+++ b/src/inspectors/IFileInspector.ts
@@ -6,6 +6,7 @@ export interface IFileInspector {
   readDirectory(path: string): Promise<string[]>;
   readFile(path: string): Promise<string>;
   writeFile(path: string, data: string): Promise<void>;
+  appendFile(path: string, data: string): Promise<void>;
   isFile(path: string): Promise<boolean>;
   isDirectory(path: string): Promise<boolean>;
   getMetadata(path: string): Promise<Metadata>;

--- a/src/practices/JavaScript/JsGitignoreCorrectlySetPractice.spec.ts
+++ b/src/practices/JavaScript/JsGitignoreCorrectlySetPractice.spec.ts
@@ -74,4 +74,34 @@ describe('JsGitignoreCorrectlySetPractice', () => {
     const evaluated = await practice.evaluate(containerCtx.practiceContext);
     expect(evaluated).toEqual(PracticeEvaluationResult.notPracticing);
   });
+
+  describe('Fixer', () => {
+    afterEach(async () => {
+      containerCtx.virtualFileSystemService.clearFileSystem();
+    });
+
+    it('Does not change correct .gitignore', async () => {
+      const gitignore = `${basicGitignore}\npackage-lock.json\n`;
+      containerCtx.virtualFileSystemService.setFileSystem({
+        '.gitignore': gitignore,
+      });
+
+      await practice.evaluate(containerCtx.practiceContext);
+      await practice.fix(containerCtx.fixerContext);
+
+      const fixedGitignore = await containerCtx.virtualFileSystemService.readFile('.gitignore');
+      expect(fixedGitignore).toBe(gitignore);
+    });
+    it('Appends to .gitignore if entry is missing', async () => {
+      containerCtx.virtualFileSystemService.setFileSystem({
+        '.gitignore': '/node_modules\n/coverage\n',
+      });
+
+      await practice.evaluate(containerCtx.practiceContext);
+      await practice.fix(containerCtx.fixerContext);
+
+      const fixedGitignore = await containerCtx.virtualFileSystemService.readFile('.gitignore');
+      expect(fixedGitignore).toBe('/node_modules\n/coverage\n\n*.log\n');
+    });
+  });
 });

--- a/src/practices/JavaScript/JsGitignoreCorrectlySetPractice.ts
+++ b/src/practices/JavaScript/JsGitignoreCorrectlySetPractice.ts
@@ -3,6 +3,7 @@ import { DxPractice } from '../DxPracticeDecorator';
 import { PracticeContext } from '../../contexts/practice/PracticeContext';
 import { PracticeBase } from '../PracticeBase';
 import { ReportDetailType } from '../../reporters/ReporterData';
+import { FixerContext } from '../../contexts/fixer/FixerContext';
 
 @DxPractice({
   id: 'JavaScript.GitignoreCorrectlySet',
@@ -14,6 +15,8 @@ import { ReportDetailType } from '../../reporters/ReporterData';
   dependsOn: { practicing: ['LanguageIndependent.GitignoreIsPresent'] },
 })
 export class JsGitignoreCorrectlySetPractice extends PracticeBase {
+  private parsedGitignore: string[] = [];
+
   async isApplicable(ctx: PracticeContext): Promise<boolean> {
     return ctx.projectComponent.language === ProgrammingLanguage.JavaScript;
   }
@@ -31,6 +34,7 @@ export class JsGitignoreCorrectlySetPractice extends PracticeBase {
     };
     const content = await ctx.root.fileInspector.readFile('.gitignore');
     const parsedGitignore = parseGitignore(content);
+    this.parsedGitignore = parsedGitignore;
 
     // lockfiles
     const packageJsonRegex = parsedGitignore.find((value: string) => /package-lock\.json/.test(value));
@@ -49,6 +53,27 @@ export class JsGitignoreCorrectlySetPractice extends PracticeBase {
 
     this.setData();
     return PracticeEvaluationResult.notPracticing;
+  }
+
+  async fix(ctx: FixerContext) {
+    const inspector = ctx.fileInspector?.basePath ? ctx.fileInspector : ctx.root.fileInspector;
+    if (!inspector) return;
+    // node_modules
+    const nodeModulesRegex = this.parsedGitignore.find((value: string) => /node_modules/.test(value));
+    // misc
+    const coverageRegex = this.parsedGitignore.find((value: string) => /coverage/.test(value));
+    const errorLogRegex = this.parsedGitignore.find((value: string) => /\.log/.test(value));
+    const fixes = [
+      nodeModulesRegex ? undefined : '/node_modules',
+      coverageRegex ? undefined : '/coverage',
+      errorLogRegex ? undefined : '*.log',
+    ]
+      .filter(Boolean)
+      .concat(''); // append newline if we add something
+
+    if (fixes.length > 1) fixes.unshift(''); // if there is something to add, make sure we start with newline
+
+    await inspector.appendFile('.gitignore', fixes.join('\n'));
   }
 
   private setData() {


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
Add a fixer for JavaScript.GitignoreCorrectlySet practice. Does not add lockfiles, due to unknown package manager.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added new practice to practice list in README.md.
- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
