### PR TITLE
Fix reporter NaN percentage

### DIFF
--- a/src/reporters/ReporterUtils.spec.ts
+++ b/src/reporters/ReporterUtils.spec.ts
@@ -36,6 +36,18 @@ describe('ReporterUtils', () => {
       expect(result.points.percentage).toEqual(100);
       expect(result.value).toEqual('100% | 1/1 (1 skipped)');
     });
+
+    it('one skipped practice', () => {
+      notPracticingHighImpactPracticeWithCtx.overridenImpact = PracticeImpact.off;
+      notPracticingHighImpactPracticeWithCtx.isOn = false;
+
+      const result = ReporterUtils.computeDXScore([notPracticingHighImpactPracticeWithCtx]);
+
+      expect(result.points.max).toEqual(0);
+      expect(result.points.total).toEqual(0);
+      expect(result.points.percentage).toEqual(0);
+      expect(result.value).toEqual('0% | 0/0 (1 skipped)');
+    });
   });
 
   describe('#getComponentsWithPractices', () => {

--- a/src/reporters/ReporterUtils.ts
+++ b/src/reporters/ReporterUtils.ts
@@ -84,7 +84,7 @@ export class ReporterUtils {
     /**
      * Compute percentage points
      */
-    score.points.percentage = Math.round((100 / score.points.max) * score.points.total);
+    score.points.percentage = score.points.max ? Math.round((100 / score.points.max) * score.points.total) : 0;
     const practicingCount = score.practices.practicing.length;
     const notPracticingCount = score.practices.notPracticing.length;
     const offCount = score.practices.off.length;


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
If none of the practices is active, reporter score was `NaN %`. This fixes it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added new practice to practice list in README.md.
- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
