### PR TITLE
Omit creds from component path

### DIFF
--- a/src/services/git/GitServiceUtils.spec.ts
+++ b/src/services/git/GitServiceUtils.spec.ts
@@ -67,4 +67,18 @@ describe('GitServiceUtils', () => {
     const response = GitServiceUtils.getComponentPath(componentMock, { ...scanningStrategy, localPath: '../dx-scannerSAJK' });
     expect(response).toEqual('https://www.github.com/DXHeroes/dx-scanner');
   });
+
+  it('Returns component path without credentials', () => {
+    const componentMock: ProjectComponent = {
+      framework: ProjectComponentFramework.UNKNOWN,
+      language: ProgrammingLanguage.JavaScript,
+      path: '../dx-scannerSAJK',
+      platform: ProjectComponentPlatform.BackEnd,
+      type: ProjectComponentType.Library,
+      repositoryPath: 'https://user:passwrod@www.github.com/DXHeroes/dx-scanner',
+    };
+
+    const response = GitServiceUtils.getComponentPath(componentMock, { ...scanningStrategy, localPath: '../dx-scannerSAJK' });
+    expect(response).toEqual('https://www.github.com/DXHeroes/dx-scanner');
+  });
 });

--- a/src/services/git/GitServiceUtils.ts
+++ b/src/services/git/GitServiceUtils.ts
@@ -74,11 +74,12 @@ export class GitServiceUtils {
       componentPath = _.replace(component.path, <string>scanningStrategy.localPath, '');
 
       // if it's root component, return repo path directly
-      if (!componentPath) {
-        return <string>component.repositoryPath;
-      }
       const parsedUrl = gitUrlParse(<string>component.repositoryPath);
       repoPath = `${parsedUrl.protocol}://${parsedUrl.resource}/${parsedUrl.full_name}`;
+
+      if (!componentPath) {
+        return repoPath;
+      }
 
       // get path to component according to service type
       urlComponentPath = GitServiceUtils.getPath(componentPath || component.path, 'master', <ServiceType>scanningStrategy.serviceType);


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
Component path is often publicly visible in reporters (e.g. on GH) so we need to omit user credentials from URL, when necessary.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added new practice to practice list in README.md.
- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
