### PR TITLE
Fix LicenseIsPresentPractice init

### DIFF
--- a/src/practices/LanguageIndependent/LicenseIsPresentPractice.ts
+++ b/src/practices/LanguageIndependent/LicenseIsPresentPractice.ts
@@ -9,7 +9,7 @@ import { runGenerator } from 'yeoman-gen-run';
 import cli from 'cli-ux';
 import { AccessType } from '../../detectors/IScanningStrategy';
 
-const env = yeoman.createEnv();
+const env = yeoman.createEnv(undefined, { console });
 env.register(require.resolve('generator-license'), 'license');
 
 interface PracticeOverride extends PracticeConfig {


### PR DESCRIPTION


<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
Pass `console` directly to yeoman-environment

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
After yeoman-environment update from 2.8 to 2.9, it uses `console.Console` ctor, which is missing from `console` object when running jest tests. Therefore, we have to pass the `console` directly to `yeoman-environment`, so that it does not try to call `console.Console` at all

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added new practice to practice list in README.md.
- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
