### PR TITLE
feat: allow users to pass apiToken in CLI or env variables

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -18,6 +18,7 @@ export default class Init {
       fix: false,
       fixPattern: undefined,
       html: false,
+      apiToken: undefined,
     });
     const scanner = container.get(Scanner);
 

--- a/src/commands/practices.ts
+++ b/src/commands/practices.ts
@@ -18,6 +18,7 @@ export default class Practices {
       fix: false,
       fixPattern: undefined,
       html: cmd.html,
+      apiToken: undefined,
     });
 
     const scanner = container.get(Scanner);

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -14,6 +14,7 @@ export default class Run {
 
     const { json, details, fail } = cmd;
     let { authorization } = cmd;
+    const { apiToken } = cmd;
 
     const hrstart = process.hrtime();
 
@@ -30,6 +31,7 @@ export default class Run {
       fix: cmd.fix,
       fixPattern: cmd.fixPattern,
       html: cmd.html,
+      apiToken,
     });
     const scanner = container.get(Scanner);
 
@@ -56,6 +58,7 @@ export default class Run {
         fix: cmd.fix,
         fixPattern: cmd.fixPattern,
         html: cmd.html,
+        apiToken,
       });
       const scanner = container.get(Scanner);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,11 @@ class DXScannerCommand {
         'credentials to the repository (in format "token" or "username:token"; can be set as ENV variable DXSCANNER_GIT_SERVICE_TOKEN)',
         process.env.DXSCANNER_GIT_SERVICE_TOKEN || process.env.GITHUB_TOKEN,
       )
+      .option(
+        '-t --apiToken <apiToken>',
+        'credentials to DX Scanner, can be set as ENV variable DXSCANNER_API_TOKEN',
+        process.env.DXSCANNER_API_TOKEN,
+      )
       .option('--ci', 'CI mode', process.env.CI === 'true')
       .option('-d --details', 'print details in reports')
       .option(
@@ -63,10 +68,7 @@ class DXScannerCommand {
       });
 
     // cmd: init
-    cmder
-      .command('init')
-      .description('Initialize DX Scanner configuration')
-      .action(Init.run);
+    cmder.command('init').description('Initialize DX Scanner configuration').action(Init.run);
 
     // cmd: practices
     cmder
@@ -82,13 +84,7 @@ class DXScannerCommand {
 
   private static validateFailInput = (value: string | undefined) => {
     if (value && !_.includes(PracticeImpact, value)) {
-      console.error(
-        'Invalid value for --fail: %s\nValid values are: %s\n',
-        value,
-        Object.keys(PracticeImpact)
-          .concat('all')
-          .join(', '),
-      );
+      console.error('Invalid value for --fail: %s\nValid values are: %s\n', value, Object.keys(PracticeImpact).concat('all').join(', '));
       process.exit(1);
     }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -73,6 +73,7 @@ export type CLIArgs = {
   fix: boolean;
   fixPattern: string;
   html: string;
+  apiToken?: string;
 };
 
 // Old model starts here

--- a/src/reporters/EnterpriseReporter.ts
+++ b/src/reporters/EnterpriseReporter.ts
@@ -22,7 +22,11 @@ export class EnterpriseReporter implements IReporter {
 
     try {
       // send data
-      await axios.post('https://provider.dxscanner.io/api/v1/data-report', reportData);
+      if (this.argumentsProvider.apiToken) {
+        await axios.post('https://provider.dxscanner.io/api/v1/data-report', reportData, {
+          headers: { apiToken: this.argumentsProvider.apiToken },
+        });
+      }
       // TODO: enable logs later, when account is available
       // console.log('You can see DX data in your DX account now.\n');
     } catch (error) {

--- a/src/scanner/ArgumentsProvider.ts
+++ b/src/scanner/ArgumentsProvider.ts
@@ -11,4 +11,5 @@ export type ArgumentsProvider = {
   fix: boolean;
   fixPattern: string | undefined;
   html: string | boolean;
+  apiToken: string | undefined;
 };

--- a/src/scanner/Scanner.ts
+++ b/src/scanner/Scanner.ts
@@ -175,9 +175,7 @@ export class Scanner {
         }
       }
 
-      await git()
-        .silent(true)
-        .clone(cloneUrl.href, localPath);
+      await git().silent(true).clone(cloneUrl.href, localPath);
     }
 
     return { serviceType, accessType, remoteUrl, localPath, isOnline };

--- a/src/test/factories/ArgumentsProviderFactory.ts
+++ b/src/test/factories/ArgumentsProviderFactory.ts
@@ -15,6 +15,7 @@ export const argumentsProviderFactory = (params: Partial<ArgumentsProvider> = {}
       fix: false,
       fixPattern: undefined,
       html: false,
+      apiToken: undefined,
     },
     params,
   );


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
Allow users to pass apiToken for DX Scanner Enterprise in CLI or env variables.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added new practice to practice list in README.md.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
