### PR TITLE
fix: move tsconfig require

### DIFF
--- a/src/practices/TypeScript/TsGitignoreCorrectlySetPractice.ts
+++ b/src/practices/TypeScript/TsGitignoreCorrectlySetPractice.ts
@@ -82,7 +82,7 @@ export class TsGitignoreCorrectlySetPractice extends PracticeBase {
       .filter(Boolean)
       .concat(''); // append newline if we add something
 
-    const tsConfig = await tsLoad.load(inspector.basePath || '.');
+    const tsConfig = await tsconfig.load(inspector.basePath || '.');
     if (tsConfig) {
       if (tsConfig.config.compilerOptions.outDir) {
         const folderName = path.basename(tsConfig.config.compilerOptions.outDir);

--- a/src/practices/TypeScript/TsGitignoreCorrectlySetPractice.ts
+++ b/src/practices/TypeScript/TsGitignoreCorrectlySetPractice.ts
@@ -66,7 +66,7 @@ export class TsGitignoreCorrectlySetPractice extends PracticeBase {
      * We need to require tsconfig here due to issues with tsconfig in DXSE
      */
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const tsLoad = require('tsconfig');
+    const tsconfig = require('tsconfig');
     const inspector = ctx.fileInspector?.basePath ? ctx.fileInspector : ctx.root.fileInspector;
     if (!inspector) return;
     // node_modules

--- a/src/practices/TypeScript/TsGitignoreCorrectlySetPractice.ts
+++ b/src/practices/TypeScript/TsGitignoreCorrectlySetPractice.ts
@@ -1,10 +1,10 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
 import { PracticeEvaluationResult, PracticeImpact, ProgrammingLanguage } from '../../model';
 import { DxPractice } from '../DxPracticeDecorator';
 import { PracticeContext } from '../../contexts/practice/PracticeContext';
 import { PracticeBase } from '../PracticeBase';
 import { ReportDetailType } from '../../reporters/ReporterData';
 import { FixerContext } from '../../contexts/fixer/FixerContext';
-import { load as tsLoad } from 'tsconfig';
 import * as path from 'path';
 
 @DxPractice({
@@ -62,6 +62,11 @@ export class TsGitignoreCorrectlySetPractice extends PracticeBase {
   }
 
   async fix(ctx: FixerContext) {
+    /**
+     * We need to require tsconfig here due to issues with tsconfig in DXSE
+     */
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const tsLoad = require('tsconfig');
     const inspector = ctx.fileInspector?.basePath ? ctx.fileInspector : ctx.root.fileInspector;
     if (!inspector) return;
     // node_modules
@@ -77,7 +82,7 @@ export class TsGitignoreCorrectlySetPractice extends PracticeBase {
       .filter(Boolean)
       .concat(''); // append newline if we add something
 
-    const tsConfig = await tsLoad(inspector.basePath || '.');
+    const tsConfig = await tsLoad.load(inspector.basePath || '.');
     if (tsConfig) {
       if (tsConfig.config.compilerOptions.outDir) {
         const folderName = path.basename(tsConfig.config.compilerOptions.outDir);
@@ -93,7 +98,6 @@ export class TsGitignoreCorrectlySetPractice extends PracticeBase {
     }
 
     if (fixes.length > 1) fixes.unshift(''); // if there is something to add, make sure we start with newline
-
     await inspector.appendFile('.gitignore', fixes.join('\n'));
   }
 


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
Move tsconfig package require to method.

## Motivation and Context
Fixes problem with tsconfig when using dxscanner as a dependency.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added new practice to practice list in README.md.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
