### PR TITLE
fix: use repository root path as a root path for FileInspector

### DIFF
--- a/src/contexts/contexts.spec.ts
+++ b/src/contexts/contexts.spec.ts
@@ -25,6 +25,7 @@ describe('Contexts (And bindings)', () => {
     serviceType: ServiceType.git,
     accessType: undefined,
     localPath: undefined,
+    rootPath: undefined,
     remoteUrl: undefined,
     isOnline: false,
   };

--- a/src/contexts/language/languageContextBinding.ts
+++ b/src/contexts/language/languageContextBinding.ts
@@ -14,6 +14,8 @@ import { PythonComponentDetector } from '../../detectors/Python/PythonComponentD
 import { PythonPackageInspector } from '../../inspectors/package/PythonPackageInspector';
 import { PackageInspectorBase } from '../../inspectors/package/PackageInspectorBase';
 import { IProjectComponentDetector } from '../../detectors/IProjectComponentDetector';
+import { ScanningStrategy } from '../../detectors';
+import { ProjectFilesBrowserService } from '../../services';
 
 export const bindLanguageContext = (container: Container) => {
   container.bind(Types.LanguageContextFactory).toFactory(
@@ -29,7 +31,12 @@ export const bindLanguageContext = (container: Container) => {
 const createLanguageContainer = (languageAtPath: LanguageAtPath, rootContainer: Container): Container => {
   const container = rootContainer.createChild();
   container.bind(Types.LanguageAtPath).toConstantValue(languageAtPath);
-  container.bind(Types.IRootFileInspector).toConstantValue(container.get(Types.IFileInspector));
+  const scanningStrategy = container.get<ScanningStrategy>(Types.ScanningStrategy);
+
+  const projectFilesBrowserService = container.get<ProjectFilesBrowserService>(Types.IProjectFilesBrowser);
+  const fileInspector = container.get<FileInspector>(Types.IFileInspector);
+  const fileInspectorForRoot = new FileInspector(projectFilesBrowserService, scanningStrategy.rootPath || fileInspector.basePath);
+  container.bind(Types.IRootFileInspector).toConstantValue(fileInspectorForRoot);
 
   bindFileAccess(languageAtPath, container);
   bindComponentDetectors(container);

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,5 +100,5 @@ process.on('uncaughtException', errorHandler);
 
 export default DXScannerCommand;
 
-export { DataReportDto, DxScoreDto, ComponentDto, SecurityIssueDto, SecurityIssueSeverity } from "./reporters"
-export { ProgrammingLanguage, ProjectComponent, ProjectComponentPlatform, ProjectComponentFramework, ProjectComponentType }  from './model';
+export { DataReportDto, DxScoreDto, ComponentDto, SecurityIssueDto, SecurityIssueSeverity } from './reporters';
+export { ProgrammingLanguage, ProjectComponent, ProjectComponentPlatform, ProjectComponentFramework, ProjectComponentType } from './model';

--- a/src/inspectors/FileInspector.ts
+++ b/src/inspectors/FileInspector.ts
@@ -1,5 +1,5 @@
 import { IFileInspector } from './IFileInspector';
-import { Metadata, MetadataType, ProjectFilesBrowserServices } from '../services/model';
+import { Metadata, MetadataType, ProjectFilesBrowserService } from '../services/model';
 import debug from 'debug';
 import { injectable, optional, inject } from 'inversify';
 import { Types } from '../types';
@@ -11,11 +11,11 @@ import { FileSystemService } from '../services';
 @injectable()
 export class FileInspector implements IFileInspector {
   readonly basePath: string | undefined;
-  private projectFilesBrowser: ProjectFilesBrowserServices;
+  private projectFilesBrowser: ProjectFilesBrowserService;
   private cache: ICache;
 
   constructor(
-    @inject(Types.IProjectFilesBrowser) projectFilesBrowser: ProjectFilesBrowserServices,
+    @inject(Types.IProjectFilesBrowser) projectFilesBrowser: ProjectFilesBrowserService,
     @inject(Types.FileInspectorBasePath) @optional() basePath: string | undefined,
   ) {
     this.basePath = basePath && this.normalizePath(basePath);

--- a/src/reporters/EnterpriseReporter.ts
+++ b/src/reporters/EnterpriseReporter.ts
@@ -51,7 +51,7 @@ export class EnterpriseReporter implements IReporter {
       const componentWithScore: ComponentDto = {
         component: cwp.component,
         dxScore: { value: dxScoreForComponent, points: dxScorePoints },
-        securityIssues: []
+        securityIssues: [],
       };
 
       report.componentsWithDxScore.push(componentWithScore);
@@ -65,12 +65,12 @@ export type DataReportDto = {
   componentsWithDxScore: ComponentDto[];
   version: string;
   id: string;
-  dxScore: DxScoreDto
+  dxScore: DxScoreDto;
 };
 
 export interface ComponentDto {
   component: ProjectComponent;
-  dxScore:  DxScoreDto,
+  dxScore: DxScoreDto;
   securityIssues: SecurityIssueDto[];
 }
 
@@ -84,7 +84,7 @@ export type SecurityIssueDto = {
 
 export type DxScoreDto = Pick<DXScoreResult, 'value' | 'points'>;
 
-export enum SecurityIssueSeverity{
+export enum SecurityIssueSeverity {
   Info = 'info',
   Low = 'low',
   Moderate = 'moderate',

--- a/src/scanner/Scanner.ts
+++ b/src/scanner/Scanner.ts
@@ -153,13 +153,14 @@ export class Scanner {
    * Clone a repository if the input is remote repository
    */
   private async preprocessData(scanningStrategy: ScanningStrategy) {
-    const { serviceType, accessType, remoteUrl, isOnline } = scanningStrategy;
-    let localPath = scanningStrategy.localPath;
+    const { serviceType, accessType, remoteUrl, rootPath, isOnline } = scanningStrategy;
+    let { localPath } = scanningStrategy;
 
     if (!isOnline) {
-      return { serviceType, accessType, remoteUrl, localPath, isOnline };
+      return { serviceType, accessType, remoteUrl, localPath, rootPath, isOnline };
     }
 
+    console.log(localPath === undefined && remoteUrl !== undefined && serviceType !== ServiceType.local);
     if (localPath === undefined && remoteUrl !== undefined && serviceType !== ServiceType.local) {
       const cloneUrl = new url.URL(remoteUrl);
       localPath = fs.mkdtempSync(path.join(os.tmpdir(), 'dx-scanner'));
@@ -177,7 +178,7 @@ export class Scanner {
       await git().silent(true).clone(cloneUrl.href, localPath);
     }
 
-    return { serviceType, accessType, remoteUrl, localPath, isOnline };
+    return { serviceType, accessType, remoteUrl, localPath, rootPath, isOnline };
   }
 
   /**

--- a/src/scanner/__MOCKS__/ScanningStrategy.mock.ts
+++ b/src/scanner/__MOCKS__/ScanningStrategy.mock.ts
@@ -3,6 +3,7 @@ import { AccessType, ServiceType } from '../../detectors/IScanningStrategy';
 export const scanningStrategy = {
   accessType: AccessType.public,
   localPath: '.',
+  rootPath: undefined,
   remoteUrl: 'www.github.com/DXHeroes/dx-scanner',
   isOnline: true,
   serviceType: ServiceType.github,

--- a/src/services/model.ts
+++ b/src/services/model.ts
@@ -1,7 +1,7 @@
 import { FileSystemService } from './FileSystemService';
 import { Git } from './git/Git';
 
-export type ProjectFilesBrowserServices = FileSystemService | Git;
+export type ProjectFilesBrowserService = FileSystemService | Git;
 
 export interface IProjectFilesBrowserService {
   exists(path: string): Promise<boolean>;


### PR DESCRIPTION
- to be able detect files for git from a root of a git repository

<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
Some practices failed because the root path for browsing files was set to the input path instead of repository root path-

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The root path of FileInspector should be a root path of a git repository for local scanning.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added new practice to practice list in README.md.
- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
