### PR TITLE
fix: recursion when the flag is false

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -4,7 +4,7 @@ import { PracticeImpact } from '../model';
 import path from 'path';
 
 export default class Init {
-  static async run() {
+  static async run(): Promise<void> {
     const scanPath = process.cwd();
 
     const container = createRootContainer({

--- a/src/commands/practices.ts
+++ b/src/commands/practices.ts
@@ -4,7 +4,7 @@ import { PracticeImpact, CLIArgs } from '../model';
 import { ReporterData } from '../reporters/ReporterData';
 
 export default class Practices {
-  static async run(cmd: CLIArgs) {
+  static async run(cmd: CLIArgs): Promise<void> {
     const scanPath = process.cwd();
 
     const container = createRootContainer({

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -8,7 +8,7 @@ import { CLIArgs } from '../model';
 import { ErrorFactory } from '../lib/errors/ErrorFactory';
 
 export default class Run {
-  static async run(path = process.cwd(), cmd: CLIArgs) {
+  static async run(path = process.cwd(), cmd: CLIArgs): Promise<void> {
     debug('cli')(cmd);
     const scanPath = path;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { errorHandler } from './lib/errors';
 const pjson = require('../package.json');
 
 class DXScannerCommand {
-  static async run() {
+  static async run(): Promise<void> {
     const cmder = new commander.Command();
 
     // default cmd config

--- a/src/scanner/Scanner.ts
+++ b/src/scanner/Scanner.ts
@@ -124,7 +124,7 @@ export class Scanner {
     cli.action.stop();
   }
 
-  async fix(practicesWithContext: PracticeWithContext[], scanningStrategy?: ScanningStrategy) {
+  async fix(practicesWithContext: PracticeWithContext[], scanningStrategy?: ScanningStrategy): Promise<void> {
     if (!this.argumentsProvider.fix) return;
     const fixablePractice = (p: PracticeWithContext) => p.practice.fix && p.evaluation === PracticeEvaluationResult.notPracticing;
     const fixPatternMatcher = this.argumentsProvider.fixPattern ? new RegExp(this.argumentsProvider.fixPattern, 'i') : null;
@@ -160,7 +160,6 @@ export class Scanner {
       return { serviceType, accessType, remoteUrl, localPath, rootPath, isOnline };
     }
 
-    console.log(localPath === undefined && remoteUrl !== undefined && serviceType !== ServiceType.local);
     if (localPath === undefined && remoteUrl !== undefined && serviceType !== ServiceType.local) {
       const cloneUrl = new url.URL(remoteUrl);
       localPath = fs.mkdtempSync(path.join(os.tmpdir(), 'dx-scanner'));
@@ -372,6 +371,9 @@ export class Scanner {
     if (!this.argumentsProvider.recursive && relevantComponents.length > 1) {
       const componentsSharedPath = sharedSubpath(relevantComponents.map((cwc) => cwc.component.path));
       const componentsAtRootPath = relevantComponents.filter((cwc) => cwc.component.path === componentsSharedPath);
+
+      // scan the first component only if recursion flag is not true && there are more than 1 components on root
+      relevantComponents = [relevantComponents[0]];
 
       // do not scan only root path if found 0 components there
       if (componentsAtRootPath.length > 0) {


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
This PR will fix the multi-recursion problem. Running DXS without --recursive will still analyse all the components. This PR takes only the first component in the array and gives it back as a relevant component for the scanner analyse.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added new practice to practice list in README.md.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
