### PR TITLE
Fix BitBucket commit list response type

### DIFF
--- a/src/services/bitbucket/BitbucketService.ts
+++ b/src/services/bitbucket/BitbucketService.ts
@@ -536,16 +536,16 @@ export class BitbucketService implements IVCSService {
     return (
       commits
         //filter duplicate committer names
-        .filter((commit, index, array) => array.findIndex((t) => t.author.user.nickname === commit.author.user.nickname) === index)
+        .filter((commit, index, array) => array.findIndex((t) => t.author?.user?.nickname === commit.author?.user?.nickname) === index)
         //create contributor object
         .map((commit) => {
           return {
             user: {
-              id: commit.author.user.uuid,
-              url: commit.author.user.links.html.href,
-              login: commit.author.user.nickname,
+              id: commit.author?.user?.uuid || '',
+              url: commit.author?.user?.links?.html?.href || '',
+              login: commit.author?.user?.nickname || '',
             },
-            contributions: commits.filter((value) => value.author.user.nickname === commit.author.user.nickname).length,
+            contributions: commits.filter((value) => value.author?.user?.nickname === commit.author?.user?.nickname).length,
           };
         })
     );
@@ -585,10 +585,10 @@ export class BitbucketService implements IVCSService {
   }
 
   private async paginateCommits(params: Params.RepositoriesListCommits) {
-    let response = <DeepRequired<Response<BitbucketCommit>>>await this.unwrap(this.client.repositories.listCommits(params));
+    let response = <Response<BitbucketCommit>>await this.unwrap(this.client.repositories.listCommits(params));
     let values = response.data.values;
     while (this.client.hasNextPage(response.data)) {
-      response = <DeepRequired<Response<BitbucketCommit>>>await this.unwrap(this.client.request(response.data.next, params));
+      response = <Response<BitbucketCommit>>await this.unwrap(this.client.request(response.data.next, params));
       values = values.concat(response.data.values);
     }
     return values;


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
DeepRequired was added a while ago to override shitty lib's typings (see https://github.com/DXHeroes/dx-scanner/commit/519346387174a90befceaa26edd5dd0a2be489de ) but it turned out, some of the fields can really be undefined in the API response.

DeepRequired then converts the response to the wrong type and the info about possible undefined of the field is lost. This fixes it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added new practice to practice list in README.md.
- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
