### PR TITLE
Promise all

### DIFF
--- a/src/contexts/language/LanguageContext.ts
+++ b/src/contexts/language/LanguageContext.ts
@@ -27,9 +27,7 @@ export class LanguageContext extends ContextBase {
     this.initableInspectors = initableInspectors;
   }
   async init(): Promise<void> {
-    for (const initableInspector of this.initableInspectors) {
-      await initableInspector.init();
-    }
+    await Promise.all(this.initableInspectors.map((initableInspector) => initableInspector.init()));
   }
 
   get path(): string {

--- a/src/scanner/Scanner.ts
+++ b/src/scanner/Scanner.ts
@@ -197,9 +197,12 @@ export class Scanner {
    */
   private async detectLanguagesAtPaths(context: ScannerContext) {
     let languagesAtPaths: LanguageAtPath[] = [];
-    for (const languageDetector of context.languageDetectors) {
-      languagesAtPaths = [...languagesAtPaths, ...(await languageDetector.detectLanguage())];
+    const languageDetectors = await Promise.all(context.languageDetectors.map((languageDetector) => languageDetector.detectLanguage()));
+
+    for (const languageDetector of languageDetectors) {
+      languagesAtPaths = [...languagesAtPaths, ...languageDetector];
     }
+
     return languagesAtPaths;
   }
 

--- a/src/services/FileSystemService.real.spec.ts
+++ b/src/services/FileSystemService.real.spec.ts
@@ -366,12 +366,15 @@ describe('FileSystemService - REAL', () => {
 
         const files: string[] = [];
 
-        await fileSystemService.flatTraverse(mockFolderPath, (meta) => {
-          files.push(meta.name);
-          return false;
-        });
+        let response = true;
+        await fileSystemService
+          .flatTraverse(mockFolderPath, (meta) => {
+            files.push(meta.name);
+            return false;
+          })
+          .catch((e) => (response = e));
 
-        expect(files.length).toEqual(1);
+        expect(response).toEqual(false);
       });
 
       it("throws an error if the root doesn't exist", async () => {

--- a/src/services/FileSystemService.real.spec.ts
+++ b/src/services/FileSystemService.real.spec.ts
@@ -366,15 +366,13 @@ describe('FileSystemService - REAL', () => {
 
         const files: string[] = [];
 
-        let response = true;
         await fileSystemService
           .flatTraverse(mockFolderPath, (meta) => {
             files.push(meta.name);
             return false;
           })
-          .catch((e) => (response = e));
-
-        expect(response).toEqual(false);
+          .then(() => fail("promise didn't fail on false return"))
+          .catch((e) => expect(e).toBe(false));
       });
 
       it("throws an error if the root doesn't exist", async () => {

--- a/src/services/FileSystemService.ts
+++ b/src/services/FileSystemService.ts
@@ -5,7 +5,6 @@ import { IProjectFilesBrowserService, Metadata, MetadataType } from './model';
 import { IFs, createFsFromVolume } from 'memfs';
 import { Volume as VSVolume, DirectoryJSON } from 'memfs/lib/volume';
 import { ErrorFactory } from '../lib/errors';
-import { reject } from 'lodash';
 
 /**
  * Service for file system browsing

--- a/src/services/FileSystemService.virtual.spec.ts
+++ b/src/services/FileSystemService.virtual.spec.ts
@@ -373,12 +373,15 @@ describe('FileSystemService - VIRTUAL', () => {
 
         const files: string[] = [];
 
-        await service.flatTraverse(mockFolderPath, (meta) => {
-          files.push(meta.name);
-          return false;
-        });
+        let response = true;
+        await service
+          .flatTraverse(mockFolderPath, (meta) => {
+            files.push(meta.name);
+            return false;
+          })
+          .catch((e) => (response = e));
 
-        expect(files.length).toEqual(1);
+        expect(response).toEqual(false);
       });
 
       it("throws an error if the root doesn't exist", async () => {

--- a/src/services/FileSystemService.virtual.spec.ts
+++ b/src/services/FileSystemService.virtual.spec.ts
@@ -373,15 +373,13 @@ describe('FileSystemService - VIRTUAL', () => {
 
         const files: string[] = [];
 
-        let response = true;
         await service
           .flatTraverse(mockFolderPath, (meta) => {
             files.push(meta.name);
             return false;
           })
-          .catch((e) => (response = e));
-
-        expect(response).toEqual(false);
+          .then(() => fail("promise didn't fail on false return"))
+          .catch((e) => expect(e).toBe(false));
       });
 
       it("throws an error if the root doesn't exist", async () => {

--- a/src/services/git/Git.spec.ts
+++ b/src/services/git/Git.spec.ts
@@ -248,12 +248,15 @@ describe('Git', () => {
 
       const files: string[] = [];
 
-      await git.flatTraverse('mockFolder', (meta) => {
-        files.push(meta.name);
-        return false;
-      });
+      let response = true;
+      await git
+        .flatTraverse('mockFolder', (meta) => {
+          files.push(meta.name);
+          return false;
+        })
+        .catch((e) => (response = e));
 
-      expect(files.length).toEqual(1);
+      expect(response).toEqual(false);
     });
 
     it("throws an error if the root doesn't exist", async () => {

--- a/src/services/git/Git.spec.ts
+++ b/src/services/git/Git.spec.ts
@@ -224,38 +224,35 @@ describe('Git', () => {
   });
 
   describe('#flatTraverse', () => {
-    it('returns keys of metadata of all results', async () => {
-      gitHubNock.getDirectory('mockFolder', ['mockFile.ts'], ['mockSubFolder']);
-      gitHubNock.getFile('mockFolder/mockFile.ts');
-      gitHubNock.getDirectory('mockFolder/mockSubFolder', ['mockSubFolderFile.txt'], []);
-      gitHubNock.getFile('mockFolder/mockSubFolder/mockSubFolderFile.txt');
-
-      const files: string[] = [];
-
-      await git.flatTraverse('mockFolder', (meta) => {
-        files.push(meta.name);
+    describe('#fetch dir and files', () => {
+      beforeEach(() => {
+        gitHubNock.getDirectory('mockFolder', ['mockFile.ts'], ['mockSubFolder']);
+        gitHubNock.getFile('mockFolder/mockFile.ts');
+        gitHubNock.getDirectory('mockFolder/mockSubFolder', ['mockSubFolderFile.txt'], []);
+        gitHubNock.getFile('mockFolder/mockSubFolder/mockSubFolderFile.txt');
       });
 
-      expect(files.length).toEqual(3);
-      expect(files).toContain('mockFile.ts');
-      expect(files).toContain('mockSubFolder');
-      expect(files).toContain('mockSubFolderFile.txt');
-    });
+      it('returns keys of metadata of all results', async () => {
+        const files: string[] = [];
 
-    it('stops on false', async () => {
-      gitHubNock.getDirectory('mockFolder', ['mockFile.ts'], ['mockSubFolder']);
-      gitHubNock.getFile('mockFolder/mockFile.ts');
-      gitHubNock.getDirectory('mockFolder/mockSubFolder', ['mockSubFolderFile.txt'], []);
-      gitHubNock.getFile('mockFolder/mockSubFolder/mockSubFolderFile.txt');
+        await git.flatTraverse('mockFolder', (meta) => {
+          files.push(meta.name);
+        });
 
-      let response = true;
-      await git
-        .flatTraverse('mockFolder', () => {
-          return false;
-        })
-        .catch((e) => (response = e));
+        expect(files.length).toEqual(3);
+        expect(files).toContain('mockFile.ts');
+        expect(files).toContain('mockSubFolder');
+        expect(files).toContain('mockSubFolderFile.txt');
+      });
 
-      expect(response).toEqual(false);
+      it('stops on false', async () => {
+        await git
+          .flatTraverse('mockFolder', () => {
+            return false;
+          })
+          .then(() => fail("promise didn't fail"))
+          .catch((e) => expect(e).toBe(false));
+      });
     });
 
     it("throws an error if the root doesn't exist", async () => {

--- a/src/services/git/Git.spec.ts
+++ b/src/services/git/Git.spec.ts
@@ -245,13 +245,12 @@ describe('Git', () => {
     it('stops on false', async () => {
       gitHubNock.getDirectory('mockFolder', ['mockFile.ts'], ['mockSubFolder']);
       gitHubNock.getFile('mockFolder/mockFile.ts');
-
-      const files: string[] = [];
+      gitHubNock.getDirectory('mockFolder/mockSubFolder', ['mockSubFolderFile.txt'], []);
+      gitHubNock.getFile('mockFolder/mockSubFolder/mockSubFolderFile.txt');
 
       let response = true;
       await git
-        .flatTraverse('mockFolder', (meta) => {
-          files.push(meta.name);
+        .flatTraverse('mockFolder', () => {
           return false;
         })
         .catch((e) => (response = e));

--- a/src/services/git/Git.ts
+++ b/src/services/git/Git.ts
@@ -95,7 +95,6 @@ export class Git implements IProjectFilesBrowserService {
 
   async flatTraverse(path: string, fn: (meta: Metadata) => void | boolean): Promise<void | boolean> {
     const dirContent = await this.readDirectory(path);
-
     await Promise.all(
       dirContent.map(async (cnt) => {
         const absolutePath = nodePath.posix.join(path, cnt);


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
Update sequentially running loops for promise resolution to concurrently running promises using Promise.all while updating tests for two functions as promises are now run concurrently.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
promise resolution sequentially takes a lot of time to resolve all when then can instead run concurrently.
<!--- If it fixes an open issue, please link to the issue here. -->
closes #287 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added new practice to practice list in README.md.
- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
