### PR TITLE
fix: Reduce unnecessary Docker image layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,17 @@
 FROM node:12.16-alpine
 
-RUN apk update && apk add  -q   \
- ca-certificates \
- git
-
-RUN yarn global add dx-scanner \
- && dx-scanner --version
-
-RUN mkdir /usr/app
-WORKDIR /usr/app
-
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh ../entrypoint.sh
 
-RUN chmod +x ../entrypoint.sh
+RUN apk update && apk add  -q   \
+  ca-certificates \
+  git && \
+  yarn global add dx-scanner \
+  && dx-scanner --version && \
+  mkdir /usr/app && \
+  chmod +x ../entrypoint.sh
+
+WORKDIR /usr/app
 
 # Code file to execute when the docker container starts up (`entrypoint.sh`)
 ENTRYPOINT ["../entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,12 @@ FROM node:12.16-alpine
 COPY entrypoint.sh ../entrypoint.sh
 
 RUN apk update && apk add  -q   \
-  ca-certificates \
-  git && \
-  yarn global add dx-scanner \
-  && dx-scanner --version && \
-  mkdir /usr/app && \
-  chmod +x ../entrypoint.sh
+ ca-certificates \
+ git \
+ && yarn global add dx-scanner \
+ && dx-scanner --version \
+ && mkdir /usr/app \
+ && chmod +x ../entrypoint.sh
 
 WORKDIR /usr/app
 


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
This modifies the Dockerfile to merge all the `RUN` commands at once rather than many commands.  

See: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In this case it does not reduce the overall size of the image at all (though it usually does in larger builds), however it still reduces the build time, and the number of image layers and intermediate images that are created during the build of the final image.

### Before
```
<none>              <none>              a97400b94f74        44 seconds ago       280MB
dxs-official        latest              8f7bc28ddbdc        44 seconds ago       280MB
<none>              <none>              c422e581e46d        45 seconds ago       280MB
<none>              <none>              665d4b0ad25e        45 seconds ago       280MB
<none>              <none>              2a98e36a131d        45 seconds ago       280MB
<none>              <none>              38065ede2166        48 seconds ago       280MB
<none>              <none>              332b7434e243        About a minute ago   107MB
node                12.16-alpine        7a48db49edbf        5 months ago        88.7MB
```

### After
```
<none>              <none>              466b6a8acc33        4 seconds ago       280MB
dxs-seth            latest              6c0e71b5f3bb        4 seconds ago       280MB
<none>              <none>              c1a8a743a71e        6 seconds ago       280MB
<none>              <none>              1ac6450db0a2        35 seconds ago      88.7MB
node                12.16-alpine        7a48db49edbf        5 months ago        88.7MB
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
> Not sure if this really falls under `Bug fix`, but this is the most appropriate of the options at least.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- N/A I have updated the documentation accordingly.
- N/A I have added new practice to practice list in README.md.
- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- N/A I have added tests to cover my changes.
- [x] All new and existing tests passed.
