### PR TITLE
fix(bitbucket): Handle disabled issue tracker

### DIFF
--- a/src/services/bitbucket/BitbucketService.spec.ts
+++ b/src/services/bitbucket/BitbucketService.spec.ts
@@ -170,6 +170,13 @@ describe('Bitbucket Service', () => {
     expect(response.totalCount).toEqual(3);
   });
 
+  it('throws an error if issue tracker is disabled', async () => {
+    bitbucketNock.listIssuesErrorResponse();
+    await expect(() => service.listIssues('pypy', 'pypy', { filter: { state: IssueState.all } })).rejects.toMatchObject({
+      message: 'Request failed with status code 404',
+    });
+  });
+
   it('returns issue in own interface', async () => {
     const mockIssue = bitbucketIssueResponseFactory({ state: BitbucketIssueState.new });
     bitbucketNock.getIssueResponse(mockIssue);

--- a/src/services/bitbucket/BitbucketService.spec.ts
+++ b/src/services/bitbucket/BitbucketService.spec.ts
@@ -170,10 +170,16 @@ describe('Bitbucket Service', () => {
     expect(response.totalCount).toEqual(3);
   });
 
-  it('throws an error if issue tracker is disabled', async () => {
+  it('returns empty response if issue tracker is disabled', async () => {
     bitbucketNock.listIssuesErrorResponse();
-    await expect(() => service.listIssues('pypy', 'pypy', { filter: { state: IssueState.all } })).rejects.toMatchObject({
-      message: 'Request failed with status code 404',
+    const response = await service.listIssues('pypy', 'pypy', { filter: { state: IssueState.all } });
+    expect(response).toEqual({
+      items: [],
+      hasNextPage: false,
+      hasPreviousPage: false,
+      page: 1,
+      perPage: 0,
+      totalCount: 0,
     });
   });
 

--- a/src/services/bitbucket/BitbucketService.ts
+++ b/src/services/bitbucket/BitbucketService.ts
@@ -285,12 +285,28 @@ export class BitbucketService implements IVCSService {
       pagelen: options?.pagination?.perPage,
     };
 
-    const response = <DeepRequired<Response<Schema.PaginatedIssues>>>await this.unwrap(
-      axios.get(apiUrl, {
-        params,
-        paramsSerializer: qs.stringify,
-      }),
-    );
+    let response;
+    try {
+      response = <DeepRequired<Response<Schema.PaginatedIssues>>>await this.unwrap(
+        axios.get(apiUrl, {
+          params,
+          paramsSerializer: qs.stringify,
+        }),
+      );
+    } catch (err) {
+      const errorMessage = err?.response?.data?.error?.message;
+      if (errorMessage === 'Repository has no issue tracker.') {
+        return {
+          items: [],
+          totalCount: 0,
+          hasNextPage: false,
+          hasPreviousPage: false,
+          page: 1,
+          perPage: 0,
+        };
+      }
+      throw err;
+    }
 
     const items = response.data.values.map((val) => ({
       user: {

--- a/src/test/factories/responses/bitbucket/listIssuesErrorResponseFactory.ts
+++ b/src/test/factories/responses/bitbucket/listIssuesErrorResponseFactory.ts
@@ -1,0 +1,5 @@
+import Bitbucket from 'bitbucket';
+
+export const bitbucketListIssuesErrorResponseFactory = (): Bitbucket.Schema.Error => {
+  return { type: 'error', error: { message: 'Repository has no issue tracker.' } };
+};

--- a/src/test/helpers/bitbucketNock.ts
+++ b/src/test/helpers/bitbucketNock.ts
@@ -5,6 +5,7 @@ import { bitbucketListIssuesResponseFactory } from '../factories/responses/bitbu
 import { bitbucketListPRsResponseFactory } from '../factories/responses/bitbucket/listPrsResponseFactory';
 import { bitbucketListPullCommitsResponseFactory } from '../factories/responses/bitbucket/listPullCommitsResponseFactory';
 import { bitbucketListCommitResponseFactory } from '../factories/responses/bitbucket/listRepoCommitsResponseFactory';
+import { bitbucketListIssuesErrorResponseFactory } from '../factories/responses/bitbucket/listIssuesErrorResponseFactory';
 import { BitbucketPullRequestState, BitbucketIssueState } from '../../services/bitbucket/IBitbucketService';
 import { VCSServicesUtils } from '../../services/git/VCSServicesUtils';
 import Bitbucket from 'bitbucket';
@@ -21,7 +22,7 @@ export class BitbucketNock {
     this.url = 'https://api.bitbucket.org/2.0';
   }
 
-  private static get(url: string, params: nock.DataMatcherMap = {}, persist = true): nock.Interceptor {
+  private static get(url: string, params: nock.DataMatcherMap | boolean = {}, persist = true): nock.Interceptor {
     const urlObj = new URL(url);
 
     const scope = nock(urlObj.origin);
@@ -30,7 +31,7 @@ export class BitbucketNock {
     }
 
     const interceptor = scope.get(urlObj.pathname);
-    if (Object.keys(params)) {
+    if (params) {
       interceptor.query(params);
     }
 
@@ -91,6 +92,12 @@ export class BitbucketNock {
     const response = bitbucketListIssuesResponseFactory(issues);
 
     return BitbucketNock.get(baseUrl, queryParams).reply(200, response);
+  }
+
+  listIssuesErrorResponse() {
+    const baseUrl = `${this.url}/repositories/${this.user}/${this.repoName}/issues`;
+    const response = bitbucketListIssuesErrorResponseFactory();
+    return BitbucketNock.get(baseUrl, true).reply(404, response);
   }
 
   getIssueResponse(issue: Bitbucket.Schema.Issue) {


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
Handle error response from Bitbucket API in `BitbucketService.listIssues` if the project has issue tracker disabled. I have also added new error mock for bitbucketNock `listIssuesErrorResponse` to test the error condition.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #263

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added new practice to practice list in README.md.
- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
