### PR TITLE
chore: clean up rust-related components

### DIFF
--- a/src/detectors/Rust/RustComponentDetector.ts
+++ b/src/detectors/Rust/RustComponentDetector.ts
@@ -76,7 +76,7 @@ export class RustComponentDetector implements IProjectComponentDetector {
       });
     }
 
-    if (result.length == 0) {
+    if (result.length === 0) {
       throw ErrorFactory.newInternalError(
         `Could not detect neither a library nor a binary Rust crate at given language path: ${langAtPath.path}`,
       );

--- a/src/detectors/Rust/RustComponentDetector.ts
+++ b/src/detectors/Rust/RustComponentDetector.ts
@@ -4,6 +4,8 @@ import { Types } from '../../types';
 import { LanguageAtPath, ProjectComponent, ProjectComponentFramework, ProjectComponentPlatform, ProjectComponentType } from '../../model';
 import { IFileInspector, RustPackageInspector } from '../../inspectors';
 import _ from 'lodash';
+import nodePath from 'path';
+import { ErrorFactory } from '../../lib/errors';
 
 @injectable()
 export class RustComponentDetector implements IProjectComponentDetector {
@@ -20,54 +22,39 @@ export class RustComponentDetector implements IProjectComponentDetector {
     // * `src/bin/*.rs`
     // * `src/bin/*/main.rs`
     // * a `bin` entry in the manifest
-    const hasBinaryFile = Promise.all([
-      this.fileInspector.exists('src/main.rs'),
-      this.fileInspector
-        .readDirectory('src/bin')
-        .then(async (entries) => {
-          for (const entry of entries) {
-            const entryPath = `src/bin/${entry}`;
-            if (
-              (entry.endsWith('.rs') && (await this.fileInspector.isFile(entryPath))) ||
-              (await this.fileInspector.isFile(`${entryPath}/main.rs`))
-            ) {
-              return true;
-            }
-          }
+    const hasMain = await this.fileInspector.exists(nodePath.join('src', 'main.rs'));
+    let hasSrcBin = false;
+    try {
+      const binFolderEntries = await this.fileInspector.readDirectory(nodePath.join('src', 'bin'));
+      for (const entry of binFolderEntries) {
+        const entryPath = nodePath.join('src', 'bin', entry);
 
-          return false;
-        })
-        .catch((err) => (err.code === 'ENOENT' ? Promise.resolve(false) : Promise.reject(err))),
-      Promise.resolve(_.get(this.packageInspector.cargoManifest, 'bin.length', 0) > 0),
-    ]).then((a) => a.some((i) => i));
+        const isRsFile = entry.endsWith('.rs') && (await this.fileInspector.isFile(entryPath));
+        if (isRsFile) {
+          hasSrcBin = true;
+          break;
+        }
 
-    // const hasMain = await this.fileInspector.exists('src/main.rs');
-    // let hasSrcBin = false;
-    // try {
-    //     const binFolderEntries = await this.fileInspector.readDirectory('src/bin');
-    //     for (const entry of binFolderEntries) {
-    //       const entryPath = `src/bin/${entry}`;
-    //       if (
-    //         (entry.endsWith('.rs') && (await this.fileInspector.isFile(entryPath))) ||
-    //         (await this.fileInspector.isFile(`${entryPath}/main.rs`))
-    //       ) {
-    //         hasSrcBin = true;
-    //       }
-    //     }
-    // } catch (e) {
-    //     if (e.code === 'ENOENT') {
-    //         // ignore
-    //     } else {
-    //         throw e;
-    //     }
-    // }
-    // const hasManifestBin = _.get(this.packageInspector.cargoManifest, 'bin.length', 0) > 0;
-    // const hasBinaryFile = hasMain || hasSrcBin || hasManifestBin;
+        const hasNestedMain = await this.fileInspector.isFile(nodePath.join(entryPath, 'main.rs'));
+        if (hasNestedMain) {
+          hasSrcBin = true;
+          break;
+        }
+      }
+    } catch (e) {
+      if (e.code === 'ENOENT') {
+        // ignore
+      } else {
+        throw e;
+      }
+    }
+    const hasManifestBin = _.get(this.packageInspector.cargoManifest, 'bin.length', 0) > 0;
+    const hasBinaryFile = hasMain || hasSrcBin || hasManifestBin;
 
     // Cargo outputs a library if and only if `src/lib.rs` exists
-    const hasLib = this.fileInspector.exists('src/lib.rs');
+    const hasLib = await this.fileInspector.exists(nodePath.join('src', 'lib.rs'));
 
-    if (await hasLib) {
+    if (hasLib) {
       result.push({
         framework: ProjectComponentFramework.UNKNOWN,
         language: langAtPath.language,
@@ -78,7 +65,7 @@ export class RustComponentDetector implements IProjectComponentDetector {
       });
     }
 
-    if (await hasBinaryFile) {
+    if (hasBinaryFile) {
       result.push({
         framework: ProjectComponentFramework.UNKNOWN,
         language: langAtPath.language,
@@ -87,6 +74,12 @@ export class RustComponentDetector implements IProjectComponentDetector {
         repositoryPath: undefined,
         type: ProjectComponentType.Application,
       });
+    }
+
+    if (result.length == 0) {
+      throw ErrorFactory.newInternalError(
+        `Could not detect neither a library nor a binary Rust crate at given language path: ${langAtPath.path}`,
+      );
     }
 
     return result;

--- a/src/inspectors/package/RustPackageInspector.ts
+++ b/src/inspectors/package/RustPackageInspector.ts
@@ -45,17 +45,27 @@ export class RustPackageInspector extends PackageInspectorBase {
     try {
       this.debug('RustPackageInspector init started');
 
-      const cargoLockString = await this.fileInspector
-        .readFile('Cargo.lock')
-        .catch((err) => (err.code === 'ENOENT' ? Promise.resolve(undefined) : Promise.reject(err)));
+      let cargoLockString = undefined;
+      try {
+        cargoLockString = await this.fileInspector.readFile('Cargo.lock');
+      } catch (err) {
+        if (err.code !== 'ENOENT') {
+          throw err;
+        }
+      }
       if (cargoLockString !== undefined) {
         const cargoLockToml = TOML.parse(cargoLockString);
         this.cargoLock = RustPackageInspector.parseLock(cargoLockToml);
       }
 
-      const cargoManifestString = await this.fileInspector
-        .readFile('Cargo.toml')
-        .catch((err) => (err.code === 'ENOENT' ? Promise.resolve(undefined) : Promise.reject(err)));
+      let cargoManifestString = undefined;
+      try {
+        cargoManifestString = await this.fileInspector.readFile('Cargo.toml');
+      } catch (err) {
+        if (err.code !== 'ENOENT') {
+          throw err;
+        }
+      }
       if (cargoManifestString !== undefined) {
         const cargoManifestToml = TOML.parse(cargoManifestString);
 

--- a/src/practices/Rust/RustGitignoreCorrectlySetPractice.spec.ts
+++ b/src/practices/Rust/RustGitignoreCorrectlySetPractice.spec.ts
@@ -76,6 +76,6 @@ describe('RustGitignoreIsCorrectlySetPractice', () => {
     await practice.fix(containerCtx.fixerContext);
 
     const fixedGitignore = await containerCtx.virtualFileSystemService.readFile('.gitignore');
-    expect(fixedGitignore).toBe(`${invalidGitignore}\n# added by \`dx-scanner --fix\`\ntarget/\n**/*.rs.bk`);
+    expect(fixedGitignore).toBe(`${invalidGitignore}\n# added by \`dx-scanner --fix\`\ntarget/\n**/*.rs.bk\n`);
   });
 });

--- a/src/practices/Rust/RustGitignoreCorrectlySetPractice.ts
+++ b/src/practices/Rust/RustGitignoreCorrectlySetPractice.ts
@@ -1,11 +1,8 @@
-import { PracticeBase } from '../PracticeBase';
-
 import { PracticeEvaluationResult, PracticeImpact, ProgrammingLanguage } from '../../model';
 import { DxPractice } from '../DxPracticeDecorator';
 import { PracticeContext } from '../../contexts/practice/PracticeContext';
 import { ReportDetailType } from '../../reporters/ReporterData';
-import { FixerContext } from '../../contexts/fixer/FixerContext';
-import { IFileInspector } from '../../inspectors';
+import { GitignoreCorrectlySetPracticeBase } from '../common/GitignoreCorrectlySetPracticeBase';
 
 @DxPractice({
   id: 'Rust.GitignoreCorrectlySet',
@@ -16,62 +13,31 @@ import { IFileInspector } from '../../inspectors';
   url: 'https://github.com/github/gitignore/blob/master/Rust.gitignore',
   dependsOn: { practicing: ['LanguageIndependent.GitignoreIsPresent'] },
 })
-export class RustGitignoreCorrectlySetPractice extends PracticeBase {
-  private IGNORE_CHECKS: [RegExp, string][] = [
-    [/target\//, 'target/'],
-    [/\*\*\/\*\.rs\.bk/, '**/*.rs.bk'],
-  ];
-
-  async isApplicable(ctx: PracticeContext): Promise<boolean> {
-    return ctx.projectComponent.language === ProgrammingLanguage.Rust;
-  }
-
-  private static async parseGitignore(fileInspector: IFileInspector): Promise<{ raw: string; rules: string[] }> {
-    const raw = await fileInspector.readFile('.gitignore');
-    const rules = raw.split('/\r?\n/').filter((line) => !line.startsWith('#') && line.trim() !== '');
-
-    return {
-      raw,
-      rules,
-    };
+export class RustGitignoreCorrectlySetPractice extends GitignoreCorrectlySetPracticeBase {
+  constructor() {
+    super();
+    this.applicableLanguages = [ProgrammingLanguage.Rust];
+    this.ruleChecks = [
+      { regex: /target\//, fix: 'target/' },
+      { regex: /\*\*\/\*\.rs\.bk/, fix: '**/*.rs.bk' },
+    ];
   }
 
   async evaluate(ctx: PracticeContext): Promise<PracticeEvaluationResult> {
-    if (!ctx.root.fileInspector) {
-      return PracticeEvaluationResult.unknown;
+    const result = await super.evaluate(ctx);
+
+    if (result === PracticeEvaluationResult.notPracticing) {
+      this.setData();
     }
+    return result;
+  }
 
-    const gitignore = await RustGitignoreCorrectlySetPractice.parseGitignore(ctx.root.fileInspector);
-    const allFound = this.IGNORE_CHECKS.every(([regex, _]) => gitignore.rules.find((v) => regex.test(v)) !== undefined);
-
-    if (allFound) {
-      return PracticeEvaluationResult.practicing;
-    }
-
+  protected setData() {
     this.data.details = [
       {
         type: ReportDetailType.text,
         text: 'You should ignore the `target` folder, and for libraries also the `Cargo.lock` file.',
       },
     ];
-    return PracticeEvaluationResult.notPracticing;
-  }
-
-  async fix(ctx: FixerContext) {
-    const inspector = ctx.fileInspector?.basePath ? ctx.fileInspector : ctx.root.fileInspector;
-    if (!inspector) return;
-
-    const gitignore = await RustGitignoreCorrectlySetPractice.parseGitignore(inspector);
-    const fixes = this.IGNORE_CHECKS.filter(([regex, _]) => gitignore.rules.find((v) => regex.test(v)) === undefined).map(
-      ([_, fix]) => fix,
-    );
-
-    if (fixes.length > 0) {
-      let fixesString = fixes.join('\n');
-      if (fixesString.length > 0) {
-        fixesString = '\n# added by `dx-scanner --fix`\n' + fixesString;
-      }
-      await inspector.writeFile('.gitignore', `${gitignore.raw}${fixesString}`);
-    }
   }
 }


### PR DESCRIPTION
## Description
* More `async/await` in lieu of `Promise.all` and `.then` chains.
* Path joining using `path.join`
* Make use if `ErrorFactory.newInternalError` for unexpected state in component detector
* Rust gitignore practice hooked up to the GitignoreCorrectlySetPracticeBase from the other PR

## Motivation and Context
Recently two of my PRs got merged, but one of them wasn't fully done. This PR cleans up the remaining issues

## Types of changes
- [x] Code cleanup

## Checklist:
- [x] All existing tests passed.
