### PR TITLE
fix: gitignore is correctly set practice

### DIFF
--- a/src/practices/Java/JavaGitignoreCorrectlySetPractice.ts
+++ b/src/practices/Java/JavaGitignoreCorrectlySetPractice.ts
@@ -49,7 +49,7 @@ export class JavaGitignoreCorrectlySetPractice extends GitignoreCorrectlySetPrac
   }
 
   async evaluate(ctx: PracticeContext): Promise<PracticeEvaluationResult> {
-    const fileInspector = GitignoreCorrectlySetPracticeBase.checkFileInspector(ctx);
+    const fileInspector = await GitignoreCorrectlySetPracticeBase.checkFileInspector(ctx);
     if (!fileInspector) {
       return PracticeEvaluationResult.unknown;
     }

--- a/src/practices/TypeScript/TsGitignoreCorrectlySetPractice.ts
+++ b/src/practices/TypeScript/TsGitignoreCorrectlySetPractice.ts
@@ -59,7 +59,7 @@ export class TsGitignoreCorrectlySetPractice extends GitignoreCorrectlySetPracti
   }
 
   async evaluate(ctx: PracticeContext): Promise<PracticeEvaluationResult> {
-    const fileInspector = GitignoreCorrectlySetPracticeBase.checkFileInspector(ctx);
+    const fileInspector = await GitignoreCorrectlySetPracticeBase.checkFileInspector(ctx);
     if (!fileInspector) {
       return PracticeEvaluationResult.unknown;
     }

--- a/src/practices/common/GitignoreCorrectlySetPracticeBase.ts
+++ b/src/practices/common/GitignoreCorrectlySetPracticeBase.ts
@@ -93,8 +93,14 @@ export abstract class GitignoreCorrectlySetPracticeBase extends PracticeBase {
     return this.applicableLanguages.includes(ctx.projectComponent.language);
   }
 
-  protected static checkFileInspector(ctx: PracticeContext): IFileInspector | undefined {
-    const inspector = ctx.fileInspector?.basePath ? ctx.fileInspector : ctx.root.fileInspector;
+  protected static async checkFileInspector(ctx: PracticeContext): Promise<IFileInspector | undefined> {
+    let inspector;
+    if (await ctx.fileInspector?.exists('.gitignore')) {
+      inspector = ctx.fileInspector;
+    } else {
+      //gitignore correctly set practice depends on gitignore is present practice - so we know there is a gitignore somewhere
+      inspector = ctx.root.fileInspector;
+    }
     // if (!inspector) {
     // TODO: Log this?
     // }
@@ -106,7 +112,7 @@ export abstract class GitignoreCorrectlySetPracticeBase extends PracticeBase {
    * Evaluates the current component by checking whether each `check` in `this.ruleChecks` matches at least one rule in the parsed `.gitignore` rules.
    */
   async evaluate(ctx: PracticeContext): Promise<PracticeEvaluationResult> {
-    const fileInspector = GitignoreCorrectlySetPracticeBase.checkFileInspector(ctx);
+    const fileInspector = await GitignoreCorrectlySetPracticeBase.checkFileInspector(ctx);
     if (!fileInspector) {
       return PracticeEvaluationResult.unknown;
     }
@@ -129,7 +135,7 @@ export abstract class GitignoreCorrectlySetPracticeBase extends PracticeBase {
    * Fixes the `.gitignore` file by collecting `fix` fields from `this.ruleChecks` which didn't pass the check and appends them at the end of the file.
    */
   async fix(ctx: FixerContext) {
-    const fileInspector = GitignoreCorrectlySetPracticeBase.checkFileInspector(ctx);
+    const fileInspector = await GitignoreCorrectlySetPracticeBase.checkFileInspector(ctx);
     if (!fileInspector) {
       return;
     }


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
We were looking for gitignore using wrong path. Method `checkFileInspector` in `GitignoreCorrectlySetPracticeBase` just returned `ctx.fileInspector` if there was a basePath in it. It didn't actually check if there is a gitignore file to read. Now we check if there is a gitignore otherwise we return `ctx.root.fileInspector` because we (thanks to gitignore is present practice) know there is a gitignore somewhere. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added new practice to practice list in README.md.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
