### PR TITLE
fix: make ServiceDataCollector optional

### DIFF
--- a/src/collectors/ServiceDataCollector.ts
+++ b/src/collectors/ServiceDataCollector.ts
@@ -5,7 +5,7 @@ import { Contributor } from '../services/git/model';
 import { ScanningStrategy } from '../detectors';
 
 @injectable()
-export class DataCollector {
+export class ServiceDataCollector {
   private readonly contributorsCollector: ContributorsCollector;
   private readonly branchesCollector: BranchesCollector;
   //TODO: add tech stack collector
@@ -16,7 +16,7 @@ export class DataCollector {
     this.contributorsCollector = contributorsCollector;
     this.branchesCollector = branchesCollector;
   }
-  async collectData(scanningStrategy: ScanningStrategy): Promise<CollectorsData> {
+  async collectData(scanningStrategy: ScanningStrategy): Promise<ServiceCollectorsData> {
     // TODO: temporary try/catch until the listBranches is implemented in all VCS connectors
     let branches = { current: 'unknown', default: 'unknown' };
     try {
@@ -29,7 +29,7 @@ export class DataCollector {
   }
 }
 
-export type CollectorsData = {
+export type ServiceCollectorsData = {
   contributors: Contributor[];
   branches: {
     default: string;

--- a/src/contexts/scanner/scannerContextBinding.ts
+++ b/src/contexts/scanner/scannerContextBinding.ts
@@ -1,7 +1,7 @@
 import { Container } from 'inversify';
 import { BranchesCollector } from '../../collectors/BranchesCollector';
 import { ContributorsCollector } from '../../collectors/ContributorsCollector';
-import { DataCollector } from '../../collectors/DataCollector';
+import { ServiceDataCollector } from '../../collectors/ServiceDataCollector';
 import { GoLanguageDetector } from '../../detectors/Go/GoLanguageDetector';
 import { AccessType, ServiceType } from '../../detectors/IScanningStrategy';
 import { JavaLanguageDetector } from '../../detectors/Java/JavaLanguageDetector';
@@ -66,10 +66,10 @@ const bindFileAccess = (scanningStrategy: ScanningStrategy, container: Container
 };
 
 const bindCollectors = (container: Container, args: ArgumentsProvider, accessType: AccessType | undefined) => {
-  if ((accessType !== AccessType.public && args.apiToken) || accessType === AccessType.public) {
+  if ((accessType === AccessType.private && args.apiToken) || accessType === AccessType.public) {
     container.bind(ContributorsCollector).toSelf().inSingletonScope();
     container.bind(BranchesCollector).toSelf().inSingletonScope();
-    container.bind(DataCollector).toSelf().inSingletonScope();
+    container.bind(ServiceDataCollector).toSelf().inSingletonScope();
   }
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,7 +111,7 @@ process.on('uncaughtException', errorHandler);
 
 export default DXScannerCommand;
 
-export { CollectorsData } from './collectors/DataCollector';
+export { ServiceCollectorsData as CollectorsData } from './collectors/ServiceDataCollector';
 export { ServiceType } from './detectors';
 export { ProgrammingLanguage, ProjectComponent, ProjectComponentFramework, ProjectComponentPlatform, ProjectComponentType } from './model';
 export * from './reporters/DashboardReporter';

--- a/src/reporters/DashboardReporter.spec.ts
+++ b/src/reporters/DashboardReporter.spec.ts
@@ -3,7 +3,7 @@ import { argumentsProviderFactory } from '../test/factories/ArgumentsProviderFac
 import { practiceWithContextFactory } from '../test/factories/PracticeWithContextFactory';
 import { DashboardReporter } from './DashboardReporter';
 import { AccessType, ServiceType } from '../detectors/IScanningStrategy';
-import { DataCollector } from '../collectors/DataCollector';
+import { ServiceDataCollector } from '../collectors/ServiceDataCollector';
 import { repositoryConfig } from '../scanner/__MOCKS__/RepositoryConfig.mock';
 import { GitHubService } from '../services';
 import { ContributorsCollector } from '../collectors/ContributorsCollector';
@@ -26,7 +26,7 @@ describe('DashboardReporter', () => {
   const gitInspector = new GitInspector('.');
   const contributorsCollector = new ContributorsCollector(githubService);
   const branchesCollector = new BranchesCollector(githubService, gitInspector);
-  const dataCollector = new DataCollector(contributorsCollector, branchesCollector);
+  const dataCollector = new ServiceDataCollector(contributorsCollector, branchesCollector);
   const gitHubNock = new GitHubNock('1', 'DXHeroes', 1, 'dx-scanner');
 
   describe('#report', () => {

--- a/src/reporters/DashboardReporter.ts
+++ b/src/reporters/DashboardReporter.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import * as uuid from 'uuid';
 import { DXScoreResult, ReporterUtils } from '.';
 import { ScanningStrategy } from '../detectors';
@@ -10,7 +10,7 @@ import { IReporter, PracticeWithContextForReporter } from './IReporter';
 import { PkgToUpdate } from '../practices/utils/DependenciesVersionEvaluationUtils';
 import { ServiceType } from '../detectors/IScanningStrategy';
 import { GitServiceUtils } from '../services';
-import { DataCollector, CollectorsData } from '../collectors/DataCollector';
+import { ServiceDataCollector, ServiceCollectorsData } from '../collectors/ServiceDataCollector';
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
 const pjson = require('../../package.json');
 
@@ -18,12 +18,12 @@ const pjson = require('../../package.json');
 export class DashboardReporter implements IReporter {
   private readonly argumentsProvider: ArgumentsProvider;
   private readonly scanningStrategy: ScanningStrategy;
-  private readonly dataCollector: DataCollector;
+  private readonly dataCollector: ServiceDataCollector | undefined;
 
   constructor(
     @inject(Types.ArgumentsProvider) argumentsProvider: ArgumentsProvider,
     @inject(Types.ScanningStrategy) scanningStrategy: ScanningStrategy,
-    @inject(DataCollector) dataCollector: DataCollector,
+    @inject(ServiceDataCollector) @optional() dataCollector: ServiceDataCollector | undefined,
   ) {
     this.argumentsProvider = argumentsProvider;
     this.scanningStrategy = scanningStrategy;
@@ -50,7 +50,7 @@ export class DashboardReporter implements IReporter {
 
     const report: DataReportDto = {
       componentsWithDxScore: [],
-      collectorsData: await this.dataCollector.collectData(this.scanningStrategy),
+      collectorsData: await this.dataCollector?.collectData(this.scanningStrategy),
       version: pjson.version,
       id: uuid.v4(),
       dxScore: { value: dxScore.value, points: dxScore.points },
@@ -101,7 +101,7 @@ export class DashboardReporter implements IReporter {
 
 export type DataReportDto = {
   componentsWithDxScore: ComponentDto[];
-  collectorsData: CollectorsData;
+  collectorsData: ServiceCollectorsData | undefined;
   version: string;
   id: string;
   dxScore: DxScoreDto;


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
Make data collector optional.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Dxs didn't run if the user uses apiToken but uses unsupported VCS.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added new practice to practice list in README.md.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
