### PR TITLE
fix: make lockfile practice only for js and ts

### DIFF
--- a/src/practices/JavaScript/JsLockfileIsPresentPractice.spec.ts
+++ b/src/practices/JavaScript/JsLockfileIsPresentPractice.spec.ts
@@ -1,5 +1,5 @@
-import { LockfileIsPresentPractice } from './LockfileIsPresentPractice';
-import { PracticeEvaluationResult } from '../../model';
+import { JsLockfileIsPresentPractice } from './JsLockfileIsPresentPractice';
+import { PracticeEvaluationResult, ProgrammingLanguage } from '../../model';
 import { TestContainerContext, createTestContainer } from '../../inversify.config';
 import shelljs from 'shelljs';
 import { sync as commandExists } from 'command-exists';
@@ -16,11 +16,11 @@ jest.mock('command-exists', () => ({
 
 describe('LockfileIsPresentPractice', () => {
   let containerCtx: TestContainerContext;
-  let practice: LockfileIsPresentPractice;
+  let practice: JsLockfileIsPresentPractice;
 
   beforeAll(() => {
     containerCtx = createTestContainer();
-    containerCtx.container.bind('LockfileIsPresentPractice').to(LockfileIsPresentPractice);
+    containerCtx.container.bind('LockfileIsPresentPractice').to(JsLockfileIsPresentPractice);
     practice = containerCtx.container.get('LockfileIsPresentPractice');
   });
 
@@ -60,9 +60,22 @@ describe('LockfileIsPresentPractice', () => {
     expect(evaluated).toEqual(PracticeEvaluationResult.unknown);
   });
 
-  it('Is always applicable', async () => {
-    const result = await practice.isApplicable();
+  it('Is applicable to JS', async () => {
+    containerCtx.practiceContext.projectComponent.language = ProgrammingLanguage.JavaScript;
+    const result = await practice.isApplicable(containerCtx.practiceContext);
     expect(result).toEqual(true);
+  });
+
+  it('Is applicable to TS', async () => {
+    containerCtx.practiceContext.projectComponent.language = ProgrammingLanguage.TypeScript;
+    const result = await practice.isApplicable(containerCtx.practiceContext);
+    expect(result).toEqual(true);
+  });
+
+  it('Is not applicable to other languages', async () => {
+    containerCtx.practiceContext.projectComponent.language = ProgrammingLanguage.Python;
+    const result = await practice.isApplicable(containerCtx.practiceContext);
+    expect(result).toEqual(false);
   });
 
   describe('fixer', () => {

--- a/src/practices/JavaScript/JsLockfileIsPresentPractice.ts
+++ b/src/practices/JavaScript/JsLockfileIsPresentPractice.ts
@@ -1,5 +1,5 @@
 import { IPractice } from '../IPractice';
-import { PracticeEvaluationResult, PracticeImpact } from '../../model';
+import { PracticeEvaluationResult, PracticeImpact, ProgrammingLanguage } from '../../model';
 import { DxPractice } from '../DxPracticeDecorator';
 import { PracticeContext } from '../../contexts/practice/PracticeContext';
 import { PackageManagerUtils, PackageManagerType } from '../utils/PackageManagerUtils';
@@ -13,9 +13,11 @@ import shell from 'shelljs';
   reportOnlyOnce: true,
   url: 'https://dxkb.io/p/lockfile',
 })
-export class LockfileIsPresentPractice implements IPractice {
-  async isApplicable(): Promise<boolean> {
-    return true;
+export class JsLockfileIsPresentPractice implements IPractice {
+  async isApplicable(ctx: PracticeContext): Promise<boolean> {
+    return (
+      ctx.projectComponent.language === ProgrammingLanguage.JavaScript || ctx.projectComponent.language === ProgrammingLanguage.TypeScript
+    );
   }
 
   async evaluate(ctx: PracticeContext): Promise<PracticeEvaluationResult> {

--- a/src/practices/JavaScript/JsLockfileIsPresentPractice.ts
+++ b/src/practices/JavaScript/JsLockfileIsPresentPractice.ts
@@ -6,7 +6,7 @@ import { PackageManagerUtils, PackageManagerType } from '../utils/PackageManager
 import shell from 'shelljs';
 
 @DxPractice({
-  id: 'LanguageIndependent.LockfileIsPresent',
+  id: 'JavaScript.LockfileIsPresent',
   name: 'Create a Lockfile',
   impact: PracticeImpact.high,
   suggestion: 'Commit a lockfile to git to have a reliable assembly across environments',

--- a/src/practices/index.ts
+++ b/src/practices/index.ts
@@ -1,7 +1,7 @@
 import { TypeScriptUsedPractice } from './JavaScript/TypeScriptUsedPractice';
 import { PrettierUsedPractice } from './JavaScript/PrettierUsedPractice';
 import { ESLintUsedPractice } from './JavaScript/ESLintUsedPractice';
-import { LockfileIsPresentPractice } from './PackageManagement/LockfileIsPresentPractice';
+import { JsLockfileIsPresentPractice } from './JavaScript/JsLockfileIsPresentPractice';
 import { JsFrontendTestingFrameworkUsedPractice } from './JavaScript/JsFrontendTestingFrameworkUsedPractice';
 import { JsLoggerUsedPractice } from './JavaScript/JsLoggerUsedPractice';
 import { LicenseIsPresentPractice } from './LanguageIndependent/LicenseIsPresentPractice';
@@ -49,7 +49,7 @@ export const practices = [
   PrettierUsedPractice,
   ESLintUsedPractice,
   ESLintWithoutErrorsPractice,
-  LockfileIsPresentPractice,
+  JsLockfileIsPresentPractice,
   JsFrontendTestingFrameworkUsedPractice,
   JsBackendTestingFrameworkUsedPractice,
   JsLoggerUsedPractice,

--- a/src/scanner/IConfigProvider.ts
+++ b/src/scanner/IConfigProvider.ts
@@ -32,7 +32,7 @@ enum Practices {
   'JavaScript.TypeScriptUsedPractice' = 'JavaScript.TypeScriptUsedPractice',
   'JavaScript.PrettierUsedPractice' = 'JavaScript.PrettierUsedPractice',
   'JavaScript.ESLintUsedPractice' = 'JavaScript.ESLintUsedPractice',
-  'LanguageIndependent.LockfileIsPresentPractice' = 'LanguageIndependent.LockfileIsPresentPractice',
+  'JavaScript.LockfileIsPresentPractice' = 'JavaScript.LockfileIsPresentPractice',
   'JavaScript.JsFrontendTestingFrameworkUsedPractice' = 'JavaScript.JsFrontendTestingFrameworkUsedPractice',
   'JavaScript.JsBackendTestingFrameworkUsedPractice' = 'JavaScript.JsBackendTestingFrameworkUsedPractice',
   'JavaScript.JsLoggerUsedPractice' = 'JavaScript.JsLoggerUsedPractice',


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added new practice to practice list in README.md.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
