### PR TITLE
feat: change default value of --fail flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Options:
   --apiUrl <apiUrl>                   URL of DX Scanner API, can be set as ENV variable DXSCANNER_API_URL (default: https://provider.dxscanner.io/api/v1)
   --ci                                CI mode (default: false)
   -d --details                        print details in reports
-  --fail <impact>                     exits process with code 1 for any non-practicing condition of given level (high|medium|small|hint|off|all) (default: "high")
+  --fail <impact>                     exits process with code 1 for any non-practicing condition of given level (high|medium|small|hint|off|all) (default: "off")
   --fix                               tries to fix problems automatically (default: false)
   --fixPattern <pattern>              fix only rules with IDs matching the regex
   -j --json                           print report in JSON (default: false)

--- a/src/test/factories/ArgumentsProviderFactory.ts
+++ b/src/test/factories/ArgumentsProviderFactory.ts
@@ -9,7 +9,7 @@ export const argumentsProviderFactory = (params: Partial<ArgumentsProvider> = {}
       auth: undefined,
       json: false,
       details: false,
-      fail: PracticeImpact.high,
+      fail: PracticeImpact.off,
       recursive: true,
       ci: false,
       fix: false,


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
Change default value of `--fail` from `high` to `off`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As discussed in #498 , we want to get rid of a situation when by default dx-scanner outputs exit code `1` if some high-impact practices fail.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have added new practice to practice list in README.md.
- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
