### PR TITLE
⚡  Better CLI startup time

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -113,7 +113,18 @@ process.on('uncaughtException', errorHandler);
 export default DXScannerCommand;
 
 export { ServiceCollectorsData as CollectorsData } from './collectors/ServiceDataCollector';
-export { ServiceType } from './detectors';
+
+export {
+  LinterIssueDto,
+  DataReportDto,
+  ComponentDto,
+  DxScoreDto,
+  SecurityIssueDto,
+  SecurityIssueSummaryDto,
+  UpdatedDependencyDto,
+  PullRequestDto,
+} from './reporters/DashboardReporter';
+export { ServiceType } from './detectors/IScanningStrategy';
+
 export { ProgrammingLanguage, ProjectComponent, ProjectComponentFramework, ProjectComponentPlatform, ProjectComponentType } from './model';
-export * from './reporters/DashboardReporter';
 export * from './reporters/DashboardReporterEnums';

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,8 @@ import { PracticeImpact } from './model';
 const pjson = require('../package.json');
 
 type AvailableCommands = 'practices' | 'init' | 'run';
-const deferLoad = (cmdName: AvailableCommands) => async (...args: unknown[]) => (await import(`./commands/${cmdName}`)).run(...args);
+const deferLoad = (cmdName: AvailableCommands) => async (...args: unknown[]) =>
+  (await import(`./commands/${cmdName}`)).default.run(...args);
 
 class DXScannerCommand {
   static async run(): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,3 +116,4 @@ export { ServiceCollectorsData as CollectorsData } from './collectors/ServiceDat
 export { ServiceType } from './detectors';
 export { ProgrammingLanguage, ProjectComponent, ProjectComponentFramework, ProjectComponentPlatform, ProjectComponentType } from './model';
 export * from './reporters/DashboardReporter';
+export * from './reporters/DashboardReporterEnums';

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,15 +3,15 @@ import * as commander from 'commander';
 import _ from 'lodash';
 import 'reflect-metadata';
 import updateNotifier from 'update-notifier';
-import Init from './commands/init';
-import Practices from './commands/practices';
-import Run from './commands/run';
 import { debugLog } from './detectors/utils';
 import { errorHandler } from './lib/errors';
 import { enableLogfile, logfile } from './lib/logfile';
 import { PracticeImpact } from './model';
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
 const pjson = require('../package.json');
+
+type AvailableCommands = 'practices' | 'init' | 'run';
+const deferLoad = (cmdName: AvailableCommands) => async (...args: unknown[]) => (await import(`./commands/${cmdName}`)).run(...args);
 
 class DXScannerCommand {
   static async run(): Promise<void> {
@@ -70,7 +70,7 @@ class DXScannerCommand {
       .option('--html [path]', 'save report in HTML', false)
       .option('-r --recursive', 'scan all components recursively in all sub folders')
       .option('--no-recursive', 'disable recursive scan in CI mode')
-      .action(Run.run)
+      .action(deferLoad('run'))
       .on('--help', () => {
         console.log('');
         console.log('Examples:');
@@ -80,14 +80,14 @@ class DXScannerCommand {
       });
 
     // cmd: init
-    cmder.command('init').description('Initialize DX Scanner configuration').action(Init.run);
+    cmder.command('init').description('Initialize DX Scanner configuration').action(deferLoad('init'));
 
     // cmd: practices
     cmder
       .command('practices')
       .description('List all practices id with name and impact')
       .option('-j --json', 'print practices in JSON')
-      .action(Practices.run);
+      .action(deferLoad('practices'));
 
     await cmder.parseAsync(process.argv);
 

--- a/src/practices/IPractice.ts
+++ b/src/practices/IPractice.ts
@@ -2,8 +2,7 @@ import { PracticeEvaluationResult } from '../model';
 import { PracticeContext } from '../contexts/practice/PracticeContext';
 import { ReportTable, ReportText } from '../reporters/ReporterData';
 import { FixerContext } from '../contexts/fixer/FixerContext';
-import { SecurityIssueDto } from '..';
-import { SecurityIssueSummaryDto, UpdatedDependencyDto, LinterIssueDto, PullRequestDto } from '../reporters';
+import { SecurityIssueSummaryDto, UpdatedDependencyDto, LinterIssueDto, PullRequestDto, SecurityIssueDto } from '../reporters';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export interface IPractice<T extends {} = {}> {

--- a/src/practices/JavaScript/ESLintWithoutErrorsPractice.ts
+++ b/src/practices/JavaScript/ESLintWithoutErrorsPractice.ts
@@ -7,11 +7,12 @@ import { FixerContext } from '../../contexts/fixer/FixerContext';
 import { PracticeContext } from '../../contexts/practice/PracticeContext';
 import { debugLog } from '../../detectors/utils';
 import { PracticeEvaluationResult, PracticeImpact, ProgrammingLanguage } from '../../model';
-import { LinterIssueDto, LinterIssueSeverity } from '../../reporters';
+import { LinterIssueDto } from '../../reporters';
 import { PracticeConfig } from '../../scanner/IConfigProvider';
 import { DxPractice } from '../DxPracticeDecorator';
 import { PracticeBase } from '../PracticeBase';
 import { PackageManagerType, PackageManagerUtils } from '../utils/PackageManagerUtils';
+import { LinterIssueSeverity } from '../../reporters/DashboardReporterEnums';
 
 interface PracticeOverride extends PracticeConfig {
   override: {

--- a/src/practices/PracticeUtils.ts
+++ b/src/practices/PracticeUtils.ts
@@ -1,6 +1,5 @@
 import shell from 'shelljs';
-import { SecurityIssueDto } from '..';
-import { SecurityIssueSummaryDto } from '../reporters';
+import { SecurityIssueSummaryDto, SecurityIssueDto } from '../reporters';
 
 export const parseYarnAudit = async (
   result: shell.ShellString,

--- a/src/practices/utils/DependenciesVersionEvaluationUtils.ts
+++ b/src/practices/utils/DependenciesVersionEvaluationUtils.ts
@@ -1,5 +1,6 @@
 import { SemverLevel, Package, PackageInspectorBase } from '../../inspectors';
-import { UpdatedDependencySeverity, UpdatedDependencyDto } from '../../reporters/DashboardReporter';
+import { UpdatedDependencyDto } from '../../reporters/DashboardReporter';
+import { UpdatedDependencySeverity } from '../../reporters/DashboardReporterEnums';
 
 export class DependenciesVersionEvaluationUtils {
   static packagesToBeUpdated(pkgsWithNewVersion: { [key: string]: string }, semverLevel: SemverLevel, pkgs: Package[]) {

--- a/src/reporters/DashboardReporter.ts
+++ b/src/reporters/DashboardReporter.ts
@@ -13,6 +13,7 @@ import { GitServiceUtils } from '../services';
 import { ServiceDataCollector, ServiceCollectorsData } from '../collectors/ServiceDataCollector';
 import { debugLog } from '../detectors/utils';
 import debug from 'debug';
+import { UpdatedDependencySeverity, SecurityIssueSeverity, LinterIssueSeverity } from './DashboardReporterEnums';
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
 const pjson = require('../../package.json');
 
@@ -144,14 +145,6 @@ export type SecurityIssueSummaryDto = {
   code: number;
 };
 
-export enum SecurityIssueSeverity {
-  Info = 'info',
-  Low = 'low',
-  Moderate = 'moderate',
-  High = 'high',
-  Critical = 'critical',
-}
-
 //updated dependencies
 export type UpdatedDependencyDto = {
   library: string;
@@ -160,12 +153,6 @@ export type UpdatedDependencyDto = {
   severity: UpdatedDependencySeverity;
 };
 
-export enum UpdatedDependencySeverity {
-  Low = 'low',
-  Moderate = 'moderate',
-  High = 'high',
-}
-
 //linter issues
 export type LinterIssueDto = {
   filePath: string;
@@ -173,11 +160,6 @@ export type LinterIssueDto = {
   type: string;
   severity: LinterIssueSeverity;
 };
-
-export enum LinterIssueSeverity {
-  Warning = 'warning',
-  Error = 'error',
-}
 
 //pull requests
 export type PullRequestDto = {

--- a/src/reporters/DashboardReporterEnums.ts
+++ b/src/reporters/DashboardReporterEnums.ts
@@ -1,0 +1,18 @@
+export enum SecurityIssueSeverity {
+  Info = 'info',
+  Low = 'low',
+  Moderate = 'moderate',
+  High = 'high',
+  Critical = 'critical',
+}
+
+export enum UpdatedDependencySeverity {
+  Low = 'low',
+  Moderate = 'moderate',
+  High = 'high',
+}
+
+export enum LinterIssueSeverity {
+  Warning = 'warning',
+  Error = 'error',
+}


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
Some refactoring of CLI startup to avoid unnecessary imports **without** breaking the interface of dx-scanner. The sub-command require is deferred and some other imports are split between the types and enums. With this change, types get compiled out in JS and enums are small to require.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some PCs (my included) are made slower than others. And even for the fast ones, we want the CLI to start really fast. My aim here is to get the starting time (at least for "empty run") under 500ms. Time under 100ms would be really great.

Here are the mean times (10 runs) for current master and version in this MR (both with cold system cache and warm cache) for running the compiled version of dx-scanner:

| | Cold cache | Warm cache |
| --- | ---: | ---: |
| master | 3 249 ms | 1 831 ms |
| MR 551 | 702 ms | 254 ms |

So during the normal usage of dx-scanner, I got under 300ms on my mediocre HW, which is a good baseline, I think :zap: 

<details>
<summary>Code used to measure the time</summary>

cold cache:
```
hyperfine --prepare 'sync; echo 3 | sudo tee /proc/sys/vm/drop_caches' -i 'node ./bin/run.js'
```

warm cache:
```
hyperfine -i --warmup 3 'node ./bin/run.js'
```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added new practice to practice list in README.md.
- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
